### PR TITLE
REG-82 fix overflowing bar charts and style errors

### DIFF
--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -7,7 +7,7 @@ import { Panel, PanelBody } from '../libs/bootstrap/panel';
 import { FacetList, FilterList } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
 
-const DataTypeStrings = [
+const dataTypeStrings = [
     {
         type: 'dbSNP IDs',
         explanation: 'Enter dbSNP ID(s) (example) or upload a list of dbSNP IDs to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).',
@@ -22,7 +22,7 @@ const DataTypeStrings = [
     },
 ];
 
-const ExampleEntries = [
+const exampleEntries = [
     {
         label: 'multiple dbSNPs',
         input: 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856',
@@ -46,9 +46,9 @@ class DataType extends React.Component {
     }
 
     toggleOpenState() {
-        this.setState((state) => {
-            return { open: !state.open };
-        });
+        this.setState((state) => ({
+            open: !state.open
+        }));
     }
 
     handleInfo() {
@@ -152,10 +152,10 @@ class AdvSearch extends React.Component {
 
                                 <div className="example-inputs">
                                     Click for example entry:
-                                    {ExampleEntries.map((entry, entryIdx) =>
+                                    {exampleEntries.map((entry, entryIdx) =>
                                         <span key={entry.label}>
                                             <ExampleEntry label={entry.label} input={entry.input} handleExample={this.handleExample} />
-                                            { entryIdx !== (ExampleEntries.length - 1) ?
+                                            { entryIdx !== (exampleEntries.length - 1) ?
                                                 'or'
                                             :
                                             null}
@@ -449,7 +449,7 @@ class RegulomeSearch extends React.Component {
                         <div className="data-types">
                             <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
                             <div className="data-types-block">
-                                {DataTypeStrings.map(d =>
+                                {dataTypeStrings.map(d =>
                                     <DataType type={d.type} explanation={d.explanation} key={d.type} />
                                 )}
                             </div>

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -7,60 +7,60 @@ import { Panel, PanelBody } from '../libs/bootstrap/panel';
 import { FacetList, FilterList } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
 
-const DataTypes = () => {
-    const handleInfo = (e) => {
-        const infoId = e.target.id.split('data-type-')[1];
-        if (infoId) {
-            const infoElement = document.getElementById(`data-explanation-${infoId}`);
-            infoElement.classList.toggle('show');
-            const iconElement = e.target.getElementsByTagName('i')[0];
-            if (e.target.getElementsByTagName('i')[0].className.indexOf('icon-caret-right') > -1) {
-                iconElement.classList.add('icon-caret-down');
-                iconElement.classList.remove('icon-caret-right');
-            } else {
-                iconElement.classList.remove('icon-caret-down');
-                iconElement.classList.add('icon-caret-right');
-            }
-        }
-    };
+const DataTypeStrings = [
+    {
+        type: 'dbSNP IDs',
+        explanation: 'Enter dbSNP ID(s) (example) or upload a list of dbSNP IDs to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).',
+    },
+    {
+        type: 'Single nucleotides',
+        explanation: 'Enter hg19 coordinates for a single nucleotide as 0-based (example) coordinates or in a BED file (example), VCF file (example), or GFF3 file (example). These coordinates will be mapped to a dbSNP IDs (if available) in addition to identifying DNA features and regulatory elements that contain the input coordinate(s).',
+    },
+    {
+        type: 'A chromosomal region',
+        explanation: 'Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based (example) coordinates or in a BED file (example) or GFF3 file (example). All dbSNP IDs with an allele frequency &gt;1% that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).',
+    },
+];
 
-    return (
-        <div className="data-types">
-            <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
-            <div className="data-types-block">
+class DataType extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            open: false,
+        };
+
+        // Bind this to non-React methods.
+        this.handleInfo = this.handleInfo.bind(this);
+    }
+
+    handleInfo() {
+        this.setState({ open: !this.state.open });
+    }
+
+    render() {
+        return (
+            <div>
                 <h4>
-                    <div id="data-type-0" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> dbSNP IDs</div>
+                    <div className="data-type" onClick={this.handleInfo} onKeyDown={this.handleInfo} role="button" tabIndex={0}>
+                        <i className={`icon ${(this.state.open) ? ' icon-caret-down' : 'icon-caret-right'}`} /> {this.props.type}
+                    </div>
                 </h4>
-                <p className="data-type-explanation" id="data-explanation-0">Enter dbSNP ID(s) (example) or upload a list of dbSNP IDs to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
-                <h4>
-                    <div id="data-type-1" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> Single nucleotides</div>
-                </h4>
-                <p className="data-type-explanation" id="data-explanation-1">Enter hg19 coordinates for a single nucleotide as 0-based (example) coordinates or in a BED file (example), VCF file (example), or GFF3 file (example). These coordinates will be mapped to a dbSNP IDs (if available) in addition to identifying DNA features and regulatory elements that contain the input coordinate(s).</p>
-                <h4>
-                    <div id="data-type-2" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> A chromosomal region</div>
-                </h4>
-                <p className="data-type-explanation" id="data-explanation-2">Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based (example) coordinates or in a BED file (example) or GFF3 file (example). All dbSNP IDs with an allele frequency &gt;1% that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
+                <p className={`data-type-explanation${(this.state.open) ? ' show' : ''}`}>{this.props.explanation}</p>
             </div>
-        </div>
-    );
+        );
+    }
+}
+
+DataType.propTypes = {
+    type: PropTypes.string.isRequired,
+    explanation: PropTypes.string.isRequired,
 };
 
-const handleExamples = (e) => {
-    const replaceNewline = (input) => {
-        const replaceAll = (str, find, replace) => str.replace(new RegExp(find, 'g'), replace);
-        const newline = String.fromCharCode(13, 10);
-        return replaceAll(input, '\\n', newline);
-    };
-
-    let exampleString = '';
-    if (e.target.id === 'example-snps') {
-        exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
-    } else if (e.target.id === 'example-coordinates') {
-        exampleString = 'chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160';
-    } else {
-        exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
-    }
-    document.getElementById('multiple-entry-input').value = replaceNewline(exampleString);
+const replaceNewline = (input) => {
+    const replaceAll = (str, find, replace) => str.replace(new RegExp(find, 'g'), replace);
+    const newline = String.fromCharCode(13, 10);
+    return replaceAll(input, '\\n', newline);
 };
 
 class AdvSearch extends React.Component {
@@ -74,16 +74,30 @@ class AdvSearch extends React.Component {
         this.state = {
             coordinates: '',
             genome: 'GRCh37',
+            searchInput: '',
         };
         /* eslint-enable react/no-unused-state */
 
         // Bind this to non-React methods.
         this.handleChange = this.handleChange.bind(this);
         this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleExamples = this.handleExamples.bind(this);
     }
 
     handleChange(e) {
-        this.newSearchTerm = e.target.value;
+        this.setState({
+            searchInput: e.target.value,
+        });
+    }
+
+    handleExamples(e) {
+        let exampleString = '';
+        if (e.target.id === 'example-snps') {
+            exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
+        } else if (e.target.id === 'example-coordinates') {
+            exampleString = 'chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160';
+        }
+        this.setState({ searchInput: replaceNewline(exampleString) });
     }
 
     handleOnFocus() {
@@ -103,10 +117,10 @@ class AdvSearch extends React.Component {
                                 <i className="icon icon-search" />Search by dbSNP ID or coordinate range (hg19)
                             </label>
                             <div className="input-group input-group-region-input">
-                                <textarea className="multiple-entry-input" id="multiple-entry-input" placeholder="Enter search parameters here." onChange={this.handleChange} name="regions" />
+                                <textarea className="multiple-entry-input" id="multiple-entry-input" placeholder="Enter search parameters here." onChange={this.handleChange} name="regions" value={this.state.searchInput} />
 
                                 <p className="example-inputs">
-                                    Click for example entry: <span className="example-input" id="example-snps" onClick={handleExamples} onKeyDown={handleExamples} role="button" tabIndex={0}>multiple dbSNPs</span> or <span className="example-input" id="example-coordinates" onClick={handleExamples} onKeyDown={handleExamples} role="button" tabIndex={0}>coordinates ranges</span>
+                                    Click for example entry: <span className="example-input" id="example-snps" onClick={e => this.handleExamples(e)} onKeyDown={this.handleExamples} role="button" tabIndex={0}>multiple dbSNPs</span> or <span className="example-input" id="example-coordinates" onClick={e => this.handleExamples(e)} onKeyDown={this.handleExamples} role="button" tabIndex={0}>coordinates ranges</span>
                                 </p>
 
                                 <input type="submit" value="Search" className="btn btn-sm btn-info" />
@@ -200,7 +214,7 @@ const ResultsTable = (props) => {
 
         assay_title: {
             title: 'Method',
-            getValue: item => (item.assay_title ? item.assay_title : item.annotation_type),
+            getValue: item => (item.assay_title || item.annotation_type),
         },
 
         biosample_term_name: {
@@ -279,7 +293,6 @@ class RegulomeSearch extends React.Component {
         // Get a sorted list of batch hubs keys with case-insensitive sort
         let visualizeKeys = [];
         if (context.visualize_batch && Object.keys(context.visualize_batch).length) {
-            console.log('getting sorted list of batch hubs keys');
             visualizeKeys = Object.keys(context.visualize_batch).sort((a, b) => {
                 const aLower = a.toLowerCase();
                 const bLower = b.toLowerCase();
@@ -364,7 +377,7 @@ class RegulomeSearch extends React.Component {
                                                 filters={filters}
                                                 searchBase={searchBase ? `${searchBase}&` : `${searchBase}?`}
                                                 onFilter={this.onFilter}
-                                                modifyFacetsFlag={true}
+                                                modifyFacetsFlag
                                             />
                                         </div>
                                     : ''}
@@ -393,7 +406,14 @@ class RegulomeSearch extends React.Component {
                     <div>
                         <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a></div>
                         <AdvSearch {...this.props} />
-                        <DataTypes />
+                        <div className="data-types">
+                            <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
+                            <div className="data-types-block">
+                                {DataTypeStrings.map(d =>
+                                    <DataType type={d.type} explanation={d.explanation} />
+                                )}
+                            </div>
+                        </div>
                     </div>
                 : null}
 

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -74,11 +74,23 @@ DataType.propTypes = {
     explanation: PropTypes.string.isRequired,
 };
 
-const ExampleEntry = (props) => {
-    return (
-        <button className="example-input" onClick={() => props.handleExample(props.input)}> {props.label} </button>
-    );
-};
+class ExampleEntry extends React.Component {
+    constructor() {
+        super();
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick(e) {
+        e.preventDefault();
+        this.props.handleExample(this.props.input);
+    }
+
+    render() {
+        return (
+            <button className="example-input" onClick={this.handleClick}> {this.props.label} </button>
+        );
+    }
+}
 
 ExampleEntry.propTypes = {
     label: PropTypes.string.isRequired,

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -87,8 +87,8 @@ ExampleEntry.propTypes = {
 };
 
 class AdvSearch extends React.Component {
-    constructor(props) {
-        super(props);
+    constructor() {
+        super();
 
         // Set intial React state.
         /* eslint-disable react/no-unused-state */

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -22,6 +22,17 @@ const DataTypeStrings = [
     },
 ];
 
+const ExampleEntries = [
+    {
+        label: 'multiple dbSNPs',
+        input: 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856',
+    },
+    {
+        label: 'coordinates ranges',
+        input: 'chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160',
+    },
+];
+
 class DataType extends React.Component {
     constructor() {
         super();
@@ -34,8 +45,14 @@ class DataType extends React.Component {
         this.handleInfo = this.handleInfo.bind(this);
     }
 
+    toggleOpenState() {
+        this.setState((state) => {
+            return { open: !state.open };
+        });
+    }
+
     handleInfo() {
-        this.setState({ open: !this.state.open });
+        this.toggleOpenState();
     }
 
     render() {
@@ -57,15 +74,21 @@ DataType.propTypes = {
     explanation: PropTypes.string.isRequired,
 };
 
-const replaceNewline = (input) => {
-    const replaceAll = (str, find, replace) => str.replace(new RegExp(find, 'g'), replace);
-    const newline = String.fromCharCode(13, 10);
-    return replaceAll(input, '\\n', newline);
+const ExampleEntry = (props) => {
+    return (
+        <button className="example-input" onClick={() => props.handleExample(props.input)}> {props.label} </button>
+    );
+};
+
+ExampleEntry.propTypes = {
+    label: PropTypes.string.isRequired,
+    input: PropTypes.string.isRequired,
+    handleExample: PropTypes.func.isRequired,
 };
 
 class AdvSearch extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         // Set intial React state.
         /* eslint-disable react/no-unused-state */
@@ -81,7 +104,7 @@ class AdvSearch extends React.Component {
         // Bind this to non-React methods.
         this.handleChange = this.handleChange.bind(this);
         this.handleOnFocus = this.handleOnFocus.bind(this);
-        this.handleExamples = this.handleExamples.bind(this);
+        this.handleExample = this.handleExample.bind(this);
     }
 
     handleChange(e) {
@@ -90,14 +113,10 @@ class AdvSearch extends React.Component {
         });
     }
 
-    handleExamples(e) {
-        let exampleString = '';
-        if (e.target.id === 'example-snps') {
-            exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
-        } else if (e.target.id === 'example-coordinates') {
-            exampleString = 'chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160';
-        }
-        this.setState({ searchInput: replaceNewline(exampleString) });
+    handleExample(exampleInput) {
+        this.setState({
+            searchInput: exampleInput,
+        });
     }
 
     handleOnFocus() {
@@ -119,9 +138,18 @@ class AdvSearch extends React.Component {
                             <div className="input-group input-group-region-input">
                                 <textarea className="multiple-entry-input" id="multiple-entry-input" placeholder="Enter search parameters here." onChange={this.handleChange} name="regions" value={this.state.searchInput} />
 
-                                <p className="example-inputs">
-                                    Click for example entry: <span className="example-input" id="example-snps" onClick={e => this.handleExamples(e)} onKeyDown={this.handleExamples} role="button" tabIndex={0}>multiple dbSNPs</span> or <span className="example-input" id="example-coordinates" onClick={e => this.handleExamples(e)} onKeyDown={this.handleExamples} role="button" tabIndex={0}>coordinates ranges</span>
-                                </p>
+                                <div className="example-inputs">
+                                    Click for example entry:
+                                    {ExampleEntries.map((entry, entryIdx) =>
+                                        <span key={entry.label}>
+                                            <ExampleEntry label={entry.label} input={entry.input} handleExample={this.handleExample} />
+                                            { entryIdx !== (ExampleEntries.length - 1) ?
+                                                'or'
+                                            :
+                                            null}
+                                        </span>
+                                    )}
+                                </div>
 
                                 <input type="submit" value="Search" className="btn btn-sm btn-info" />
                                 <input type="hidden" name="genome" value={this.state.genome} />

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -410,7 +410,7 @@ class RegulomeSearch extends React.Component {
                             <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
                             <div className="data-types-block">
                                 {DataTypeStrings.map(d =>
-                                    <DataType type={d.type} explanation={d.explanation} />
+                                    <DataType type={d.type} explanation={d.explanation} key={d.type} />
                                 )}
                             </div>
                         </div>

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -1,66 +1,67 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import url from 'url';
-import { BrowserSelector } from './objectutils';
-import { Panel, PanelBody } from '../libs/bootstrap/panel';
-import { FacetList, FilterList, Listing, ResultBrowser } from './search';
-import { FetchedData, Param } from './fetched';
-import * as globals from './globals';
 import _ from 'underscore';
+import url from 'url';
+import * as globals from './globals';
+import { Panel, PanelBody } from '../libs/bootstrap/panel';
+import { FacetList, FilterList } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
 
-
-const regulomeGenomes = [
-    { value: 'GRCh37', display: 'hg19' },
-    { value: 'GRCh38', display: 'GRCh38' },
-];
-
-class DataTypes extends React.Component {
-
-    constructor() {
-        super();
-
-        // Bind this to non-React methods.
-        this.handleInfo = this.handleInfo.bind(this);
-    }
-
-    handleInfo(e) {
-        let infoId = e.target.id.split("data-type-")[1];
-        if (infoId){
-            let infoElement = document.getElementById("data-explanation-"+infoId);
-            infoElement.classList.toggle("show");
-            let iconElement = e.target.getElementsByTagName("i")[0];
-            if (e.target.getElementsByTagName("i")[0].className.indexOf("icon-caret-right") > -1){
-                iconElement.classList.add("icon-caret-down");
-                iconElement.classList.remove("icon-caret-right");
+const DataTypes = () => {
+    const handleInfo = (e) => {
+        const infoId = e.target.id.split('data-type-')[1];
+        if (infoId) {
+            const infoElement = document.getElementById(`data-explanation-${infoId}`);
+            infoElement.classList.toggle('show');
+            const iconElement = e.target.getElementsByTagName('i')[0];
+            if (e.target.getElementsByTagName('i')[0].className.indexOf('icon-caret-right') > -1) {
+                iconElement.classList.add('icon-caret-down');
+                iconElement.classList.remove('icon-caret-right');
             } else {
-                iconElement.classList.remove("icon-caret-down");
-                iconElement.classList.add("icon-caret-right");
+                iconElement.classList.remove('icon-caret-down');
+                iconElement.classList.add('icon-caret-right');
             }
         }
-    }
+    };
 
-    render () {
-        return(
-            <div className="data-types">
-                <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
-                <div className="data-types-block" onClick={this.handleInfo}>
-                    <h4 id="data-type-0" className="data-type"><i className="icon icon-caret-right" /> dbSNP IDs</h4>
-                    <p className="data-type-explanation" id="data-explanation-0">Enter dbSNP ID(s) (example) or upload a list of dbSNP IDs to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
-                    <h4 id="data-type-1" className="data-type"><i className="icon icon-caret-right" /> Single nucleotides</h4>
-                    <p className="data-type-explanation" id="data-explanation-1">Enter hg19 coordinates for a single nucleotide as 0-based (example) coordinates or in a BED file (example), VCF file (example), or GFF3 file (example). These coordinates will be mapped to a dbSNP IDs (if available) in addition to identifying DNA features and regulatory elements that contain the input coordinate(s).</p>
-                    <h4 id="data-type-2" className="data-type"><i className="icon icon-caret-right" /> A chromosomal region</h4>
-                    <p className="data-type-explanation" id="data-explanation-2">Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based (example) coordinates or in a BED file (example) or GFF3 file (example). All dbSNP IDs with an allele frequency >1% that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
-                </div>
+    return (
+        <div className="data-types">
+            <div className="data-types-instructions"><h4>Use RegulomeDB to identify DNA features and regulatory elements in non-coding regions of the human genome by entering ...</h4></div>
+            <div className="data-types-block">
+                <h4>
+                    <div id="data-type-0" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> dbSNP IDs</div>
+                </h4>
+                <p className="data-type-explanation" id="data-explanation-0">Enter dbSNP ID(s) (example) or upload a list of dbSNP IDs to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
+                <h4>
+                    <div id="data-type-1" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> Single nucleotides</div>
+                </h4>
+                <p className="data-type-explanation" id="data-explanation-1">Enter hg19 coordinates for a single nucleotide as 0-based (example) coordinates or in a BED file (example), VCF file (example), or GFF3 file (example). These coordinates will be mapped to a dbSNP IDs (if available) in addition to identifying DNA features and regulatory elements that contain the input coordinate(s).</p>
+                <h4>
+                    <div id="data-type-2" className="data-type" onClick={handleInfo} onKeyDown={handleInfo} role="button" tabIndex={0}><i className="icon icon-caret-right" /> A chromosomal region</div>
+                </h4>
+                <p className="data-type-explanation" id="data-explanation-2">Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based (example) coordinates or in a BED file (example) or GFF3 file (example). All dbSNP IDs with an allele frequency &gt;1% that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNP(s).</p>
             </div>
-        )
-    }
-}
-
-DataTypes.propTypes = {
-    handleInfo: PropTypes.func,
+        </div>
+    );
 };
 
+const handleExamples = (e) => {
+    const replaceNewline = (input) => {
+        const replaceAll = (str, find, replace) => str.replace(new RegExp(find, 'g'), replace);
+        const newline = String.fromCharCode(13, 10);
+        return replaceAll(input, '\\n', newline);
+    };
+
+    let exampleString = '';
+    if (e.target.id === 'example-snps') {
+        exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
+    } else if (e.target.id === 'example-coordinates') {
+        exampleString = 'chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160';
+    } else {
+        exampleString = 'rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856';
+    }
+    document.getElementById('multiple-entry-input').value = replaceNewline(exampleString);
+};
 
 class AdvSearch extends React.Component {
     constructor() {
@@ -79,7 +80,6 @@ class AdvSearch extends React.Component {
         // Bind this to non-React methods.
         this.handleChange = this.handleChange.bind(this);
         this.handleOnFocus = this.handleOnFocus.bind(this);
-        this.handleExamples = this.handleExamples.bind(this);
     }
 
     handleChange(e) {
@@ -90,33 +90,8 @@ class AdvSearch extends React.Component {
         this.context.navigate(this.context.location_href);
     }
 
-    handleExamples(e){
-
-        let replaceNewline = (input) => {
-
-            let replaceAll = (str, find, replace) => {
-                return str.replace(new RegExp(find, 'g'), replace);
-            }
-
-            var newline = String.fromCharCode(13, 10);
-            return replaceAll(input, "\\n", newline);
-        }
-
-        let exampleString = "";
-        if (e.target.id === "example-snps") {
-            exampleString = "rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856";
-        } else if (e.target.id === "example-coordinates") {
-            exampleString = "chr11:62607065-62607067\nchr10:5894500-5894501\nchr10:11741181-11741181\nchr1:39492463-39492463\nchr6:10695158-10695160";
-        } else {
-            exampleString = "rs3768324\nrs75982468\nrs10905307\nrs10823321\nrs7745856";
-        }
-        document.getElementById("multiple-entry-input").value = replaceNewline(exampleString);
-    }
-
     render() {
         const context = this.props.context;
-        const id = url.parse(this.context.location_href, true);
-        const region = id.query.region || '';
         const searchBase = url.parse(this.context.location_href).search || '';
 
         return (
@@ -124,12 +99,15 @@ class AdvSearch extends React.Component {
                 <PanelBody>
                     <form id="panel1" className="adv-search-form" autoComplete="off" aria-labelledby="tab1" onSubmit={this.handleOnFocus} >
                         <div className="form-group">
-                            <label htmlFor="annotation"><i className="icon icon-search"></i>Search by dbSNP ID or coordinate range (hg19)</label>
+                            <label htmlFor="annotation">
+                                <i className="icon icon-search" />Search by dbSNP ID or coordinate range (hg19)
+                            </label>
                             <div className="input-group input-group-region-input">
-                                <textarea className="multiple-entry-input" id="multiple-entry-input" placeholder="Enter search parameters here." onChange={this.handleChange} name="regions">
-                                </textarea>
+                                <textarea className="multiple-entry-input" id="multiple-entry-input" placeholder="Enter search parameters here." onChange={this.handleChange} name="regions" />
 
-                                <p className="example-inputs" onClick={this.handleExamples}>Click for example entry: <span className="example-input" id="example-snps">multiple dbSNPs</span> or <span className="example-input" id="example-coordinates">coordinates ranges</span></p>
+                                <p className="example-inputs">
+                                    Click for example entry: <span className="example-input" id="example-snps" onClick={handleExamples} onKeyDown={handleExamples} role="button" tabIndex={0}>multiple dbSNPs</span> or <span className="example-input" id="example-coordinates" onClick={handleExamples} onKeyDown={handleExamples} role="button" tabIndex={0}>coordinates ranges</span>
+                                </p>
 
                                 <input type="submit" value="Search" className="btn btn-sm btn-info" />
                                 <input type="hidden" name="genome" value={this.state.genome} />
@@ -147,7 +125,7 @@ class AdvSearch extends React.Component {
                     {(context.regulome_score) ?
                         <p className="regulomescore">RegulomeDB score: {context.regulome_score}</p>
                     : null}
-                    {(context.regulome_score  && !context.peak_details) ?
+                    {(context.regulome_score && !context.peak_details) ?
                         <a
                             rel="nofollow"
                             className="btn btn-info btn-sm"
@@ -178,7 +156,6 @@ AdvSearch.contextTypes = {
 };
 
 const PeakDetails = (props) => {
-
     const context = props.context;
     const peaks = context.peak_details;
 
@@ -189,7 +166,7 @@ const PeakDetails = (props) => {
 
         chrom: {
             title: 'Chromosome location',
-            getValue: item => item.chrom+":"+item.start+".."+item.end,
+            getValue: item => `${item.chrom}:${item.start}..${item.end}`,
         },
 
         biosample_term_name: {
@@ -209,22 +186,21 @@ const PeakDetails = (props) => {
             </SortTablePanel>
         </div>
     );
+};
 
-}
+PeakDetails.propTypes = {
+    context: React.PropTypes.object.isRequired,
+};
 
 const ResultsTable = (props) => {
-
     const context = props.context;
-    const data = context["@graph"];
-    
-    console.log("building table of length:");
-    console.log(data.length);
+    const data = context['@graph'];
 
     const dataColumns = {
 
         assay_title: {
             title: 'Method',
-            getValue: item => item.assay_title ? item.assay_title : item.annotation_type,
+            getValue: item => (item.assay_title ? item.assay_title : item.annotation_type),
         },
 
         biosample_term_name: {
@@ -233,19 +209,17 @@ const ResultsTable = (props) => {
 
         target: {
             title: 'Targets',
-            getValue: (item) => (item.target) ? item.target.label : (item.targets) ? item.targets.map(t => t.label).join(', ') : '',
+            getValue: item => (item.target ? item.target.label : (item.targets) ? item.targets.map(t => t.label).join(', ') : ''),
         },
 
         organ_slims: {
             title: 'Organ',
-            getValue: (item) => item.organ_slims ? item.organ_slims.join(', ') : '',
+            getValue: item => (item.organ_slims ? item.organ_slims.join(', ') : ''),
         },
 
         accession: {
-            title: "Link",
-            display: (item) => {
-                return <a href={item['@id']}>{item.accession}</a>;
-            }
+            title: 'Link',
+            display: item => <a href={item['@id']}>{item.accession}</a>,
         },
 
         description: {
@@ -260,18 +234,24 @@ const ResultsTable = (props) => {
             </SortTablePanel>
         </div>
     );
+};
 
-}
+ResultsTable.propTypes = {
+    context: React.PropTypes.object.isRequired,
+};
 
 class RegulomeSearch extends React.Component {
     constructor() {
         super();
 
-        let assemblies = 'hg19';
-        this.assembly == 'hg19';
+        this.assembly = 'hg19';
 
         // Bind this to non-React methods.
         this.onFilter = this.onFilter.bind(this);
+    }
+
+    shouldComponentUpdate(nextProps) {
+        return !_.isEqual(this.props, nextProps);
     }
 
     onFilter(e) {
@@ -282,132 +262,41 @@ class RegulomeSearch extends React.Component {
             e.preventDefault();
         }
     }
-    
-    // shouldComponentUpdate(nextProps) {
-    //     console.log("should the component update?");
-    //     let currentResultsLength = this.props.context['@graph'].length;
-    //     let nextResultsLength = nextProps.context['@graph'].length;
-    //     if (currentResultsLength > 0){
-    //         console.log(currentResultsLength===nextResultsLength);
-    //         return currentResultsLength===nextResultsLength;
-    //     } else {
-    //         console.log(true);
-    //         return true;
-    //     }
-    // }
-    
-    shouldComponentUpdate(nextProps) {
-        console.log("should the component update?");
-        console.log(!_.isEqual(this.props, nextProps));
-        return !_.isEqual(this.props, nextProps);
-    }
 
     render() {
         const visualizeLimit = 100;
         const context = this.props.context;
         const results = context['@graph'];
-        const columns = context.columns;
         const notification = context.notification;
         const searchBase = url.parse(this.context.location_href).search || '';
-        const trimmedSearchBase = searchBase.replace(/[?|&]limit=all/, '');
         const filters = context.filters;
         const facets = context.facets;
         const total = context.total;
         const visualizeDisabled = total > visualizeLimit;
-        
-        console.log("rendering with length:");
-        console.log(results.length);
 
-        let browseAllFiles = true; // True to pass all files to browser
-        let browserAssembly = ''; // Assembly to pass to ResultsBrowser component
-        let browserDatasets = []; // Datasets will be used to get vis_json blobs
-        let browserFiles = []; // Files to pass to ResultsBrowser component
-        let assemblyChooser;
-        let visualizeCfg = context.visualize_batch;
+        const visualizeCfg = context.visualize_batch;
 
         // Get a sorted list of batch hubs keys with case-insensitive sort
         let visualizeKeys = [];
         if (context.visualize_batch && Object.keys(context.visualize_batch).length) {
-            console.log("getting sorted list of batch hubs keys");
+            console.log('getting sorted list of batch hubs keys');
             visualizeKeys = Object.keys(context.visualize_batch).sort((a, b) => {
                 const aLower = a.toLowerCase();
                 const bLower = b.toLowerCase();
                 return (aLower > bLower) ? 1 : ((aLower < bLower) ? -1 : 0);
             });
         }
-        
-        // // Check whether the search query qualifies for a genome browser display. Start by counting
-        // // the number of "type" filters exist.
-        // let typeFilter;
-        // const counter = filters.reduce((prev, curr) => {
-        //     if (curr.field === 'type') {
-        //         typeFilter = curr;
-        //         return prev + 1;
-        //     }
-        //     return prev;
-        // }, 0);
-        // 
-        // // If we have only one "type" term in the query string and it's for File, then we can
-        // // display the List/Browser tabs. Otherwise we just get the list.
-        // let browserAvail = counter === 1 && typeFilter && typeFilter.term === 'File' && assemblies.length === 1;
-        // console.log("is browser available?");
-        // console.log(browserAvail);
-        // if (browserAvail) {
-        //     // If dataset is in the query string, we can show all files.
-        //     const datasetFilter = filters.find(filter => filter.field === 'dataset');
-        //     if (datasetFilter) {
-        //         browseAllFiles = true;
-        // 
-        //         // Probably not worth a define in globals.js for visualizable types and statuses.
-        //         browserFiles = results.filter(file => ['bigBed', 'bigWig'].indexOf(file.file_format) > -1);
-        //         if (browserFiles.length > 0) {
-        //             browserFiles = browserFiles.filter(file =>
-        //                 ['released', 'in progress', 'archived'].indexOf(file.status) > -1
-        //             );
-        //         }
-        //         browserAvail = (browserFiles.length > 0);
-        // 
-        //         if (browserAvail) {
-        //             // Distill down to a list of datasets so they can be passed to genome_browser code.
-        //             browserDatasets = browserFiles.reduce((datasets, file) => (
-        //                 (!file.dataset || datasets.indexOf(file.dataset) > -1) ? datasets : datasets.concat(file.dataset)
-        //             ), []);
-        //         }
-        //     } else {
-        //         browseAllFiles = false;
-        //         browserAvail = false; // NEW: Limit browser option to type=File&dataset=... only!
-        //     }
-        // }
-
-        // if (browserAvail) {
-        //     // Now determine if we have a mix of assemblies in the files, or just one. If we have
-        //     // a mix, we need to render a drop-down.
-        //     if (assemblies.length === 1) {
-        //         // Only one assembly in all the files. No menu needed.
-        //         browserAssembly = assemblies[0];
-        //         // empty div to avoid warning only.
-        //         assemblyChooser = (
-        //             <div className="browser-assembly-chooser" />
-        //         );
-        //     } else {
-        //         browserAssembly = this.state.browserAssembly;
-        //         assemblyChooser = (
-        //             <div className="browser-assembly-chooser">
-        //                 <div className="browser-assembly-chooser__title">Assembly:</div>
-        //                 <div className="browser-assembly-chooser__menu">
-        //                     <AssemblyChooser assemblies={assemblies} assemblyChange={this.assemblyChange} />
-        //                 </div>
-        //             </div>
-        //         );
-        //     }
-        // }
 
         return (
             <div>
 
                 {(context.total > 0) ?
                     <div>
-                        <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif"></img></a></div>
+                        <div className="lead-logo">
+                            <a href="/">
+                                <img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" />
+                            </a>
+                        </div>
                         <div>
                             <div className="result-summary">
                                 {(context.regulome_score) ?
@@ -425,16 +314,20 @@ class RegulomeSearch extends React.Component {
                             <div className="button-collection">
                                 {visualizeKeys && context.visualize_batch && !visualizeDisabled ?
                                     <div className="visualize-block">
-                                        {visualizeCfg['hg19']['UCSC'] ?
+                                        {visualizeCfg.hg19.UCSC ?
                                             <div>
-                                                <div className="visualize-element"><a href={visualizeCfg['hg19']['Quick View']} rel="noopener noreferrer" target="_blank">
-                                                    <i className="icon icon-external-link"></i>
+                                                <div className="visualize-element">
+                                                    <a href={visualizeCfg.hg19['Quick View']} rel="noopener noreferrer" target="_blank">
+                                                        <i className="icon icon-external-link" />
                                                     Visualize: Quick View
-                                                </a></div>
-                                                <div className="visualize-element"><a href={visualizeCfg['hg19']['UCSC']} rel="noopener noreferrer" target="_blank">
-                                                    <i className="icon icon-external-link"></i>
+                                                    </a>
+                                                </div>
+                                                <div className="visualize-element">
+                                                    <a href={visualizeCfg.hg19.UCSC} rel="noopener noreferrer" target="_blank">
+                                                        <i className="icon icon-external-link" />
                                                     UCSC browser
-                                                </a></div>
+                                                    </a>
+                                                </div>
                                             </div>
                                         :
                                             <div className="visualize-element visualize-error">To visualize, choose other datasets.</div>
@@ -445,13 +338,13 @@ class RegulomeSearch extends React.Component {
                                         <div className="visualize-element visualize-error">Filter to fewer than 100 results to visualize</div>
                                     </div>
                                 }
-                                {(context.regulome_score  && !context.peak_details) ?
+                                {(context.regulome_score && !context.peak_details) ?
                                     <a
                                         rel="nofollow"
                                         className="peaks-link"
                                         href={searchBase ? `${searchBase}&peak_metadata` : '?peak_metadata'}
                                     >
-                                        <i className="icon icon-external-link"></i>
+                                        <i className="icon icon-external-link" />
                                         View peak details
                                     </a>
                                 : null}
@@ -471,7 +364,7 @@ class RegulomeSearch extends React.Component {
                                                 filters={filters}
                                                 searchBase={searchBase ? `${searchBase}&` : `${searchBase}?`}
                                                 onFilter={this.onFilter}
-                                                modifyFacetsFlag={1}
+                                                modifyFacetsFlag={true}
                                             />
                                         </div>
                                     : ''}
@@ -491,18 +384,18 @@ class RegulomeSearch extends React.Component {
 
                 {(context.peak_details) ?
                     <div>
-                        <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif"></img></a></div>
+                        <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a></div>
                         <PeakDetails {...this.props} />
                     </div>
                 : null}
 
-                {(context.peak_details === undefined && !notification.startsWith('Success')) ? 
+                {(context.peak_details === undefined && !notification.startsWith('Success')) ?
                     <div>
-                        <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif"></img></a></div>
+                        <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a></div>
                         <AdvSearch {...this.props} />
                         <DataTypes />
                     </div>
-                :  null}
+                : null}
 
             </div>
         );

--- a/src/encoded/static/components/regulome_summary.js
+++ b/src/encoded/static/components/regulome_summary.js
@@ -50,42 +50,40 @@ SNPSummary.defaultProps = {
     summaries: [],
 };
 
-class RegulomeSummary extends React.Component {
-    render() {
-        const context = this.props.context;
-        const summaries = context.summaries;
-        const notifications = context.notifications;
-        const coordinates = context.coordinates;
+const RegulomeSummary = (props) => {
+    const context = props.context;
+    const summaries = context.summaries;
+    const notifications = context.notifications;
+    const coordinates = context.coordinates;
 
-        let snpCount = 0;
-        summaries.forEach((summary) => {
-            snpCount += summary.rsids.length;
-        });
+    let snpCount = 0;
+    summaries.forEach((summary) => {
+        snpCount += summary.rsids.length;
+    });
 
-        return (
-            <div>
-                <div className="lead-logo">
-                    <a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a>
-                </div>
+    return (
+        <div>
+            <div className="lead-logo">
+                <a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a>
+            </div>
 
-                <div className="results-summary">
-                    <p>This search has evaluated {context.notifications.length} input lines and found {snpCount} SNP(s).</p>
-                    {notifications.map((notification, idx) => {
-                        if (notification[coordinates[idx]] !== 'Success') {
-                            return (<p key={idx}>Region {coordinates[idx]} {notification[coordinates[idx]]}</p>);
-                        }
-                        return null;
-                    })}
-
-                </div>
-
-                <div className="summary-table-hoverable">
-                    <SNPSummary {...this.props} />
-                </div>
+            <div className="results-summary">
+                <p>This search has evaluated {context.notifications.length} input lines and found {snpCount} SNP(s).</p>
+                {notifications.map((notification, idx) => {
+                    if (notification[coordinates[idx]] !== 'Success') {
+                        return (<p key={idx}>Region {coordinates[idx]} {notification[coordinates[idx]]}</p>);
+                    }
+                    return null;
+                })}
 
             </div>
-        );
-    }
+
+            <div className="summary-table-hoverable">
+                <SNPSummary {...props} />
+            </div>
+
+        </div>
+    );
 };
 
 RegulomeSummary.propTypes = {

--- a/src/encoded/static/components/regulome_summary.js
+++ b/src/encoded/static/components/regulome_summary.js
@@ -1,44 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import url from 'url';
-import { BrowserSelector } from './objectutils';
-import { Panel, PanelBody } from '../libs/bootstrap/panel';
-// import { FacetList, Listing, ResultBrowser } from './search';
-// import { FetchedData, Param } from './fetched';
 import * as globals from './globals';
-// import _ from 'underscore';
 import { SortTablePanel, SortTable } from './sorttable';
 
 
 const SNPSummary = (props) => {
-
     const snps = props.context.summaries;
 
     const snpsColumns = {
         chrom: {
             title: 'Chromosome location',
             display: (item) => {
-                let href_score = '../regulome-search/?region='+item.chrom+':'+item.start+'-'+item.end+'&genome=GRCh37';
-                return <a href={href_score}>{item.chrom+":"+item.start+".."+item.end}</a>;
+                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+                return <a href={hrefScore}>{`${item.chrom}:${item.start}..${item.end}`}</a>;
             },
         },
         rsids: {
             title: 'dbSNP IDs',
             display: (item) => {
-                let href_score = '../regulome-search/?region='+item.chrom+':'+item.start+'-'+item.end+'&genome=GRCh37';
-                return <a href={href_score}>{item.rsids.join(', ')}</a>;
+                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+                return <a href={hrefScore}>{item.rsids.join(', ')}</a>;
             },
         },
         regulome_score: {
             title: 'Regulome score',
             display: (item) => {
-                if (item.regulome_score !== "N/A" && item.regulome_score !== null){
-                    let href_score = '../regulome-search/?region='+item.chrom+':'+item.start+'-'+item.end+'&genome=GRCh37';
-                    return <a href={href_score}>{item.regulome_score}</a>;
-                } else {
-                    let href_score = '../regulome-search/?region='+item.chrom+':'+item.start+'-'+item.end+'&genome=GRCh37';
-                    return <a href={href_score}>See related experiments</a>;
+                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+                if (item.regulome_score !== 'N/A' && item.regulome_score !== null) {
+                    return <a href={hrefScore}>{item.regulome_score}</a>;
                 }
+                return <a href={hrefScore}>See related experiments</a>;
             },
         },
     };
@@ -49,31 +40,42 @@ const SNPSummary = (props) => {
             </SortTablePanel>
         </div>
     );
- }
+};
+
+SNPSummary.propTypes = {
+    context: React.PropTypes.object.isRequired,
+    summaries: React.PropTypes.array,
+};
+
+SNPSummary.defaultProps = {
+    summaries: [],
+};
 
 class RegulomeSummary extends React.Component {
-
     render() {
         const context = this.props.context;
         const summaries = context.summaries;
         const notifications = context.notifications;
         const coordinates = context.coordinates;
 
-        let snp_count = 0;
-        summaries.forEach(summary => {
-            snp_count += summary.rsids.length;
-        })
+        let snpCount = 0;
+        summaries.forEach((summary) => {
+            snpCount += summary.rsids.length;
+        });
 
         return (
             <div>
-                <div className="lead-logo"><a href="/"><img src="/static/img/RegulomeLogoFinal.gif"></img></a></div>
+                <div className="lead-logo">
+                    <a href="/"><img src="/static/img/RegulomeLogoFinal.gif" alt="Regulome logo" /></a>
+                </div>
 
                 <div className="results-summary">
-                    <p>This search has evaluated {context.notifications.length} input lines and found {snp_count} SNP(s).</p>
-                    {notifications.map((notification,idx) => {
-                        if (notification[coordinates[idx]] !== "Success") {
-                            return (<p key={idx}>Region {coordinates[idx]} {notification[coordinates[idx]]}</p>)
+                    <p>This search has evaluated {context.notifications.length} input lines and found {snpCount} SNP(s).</p>
+                    {notifications.map((notification, idx) => {
+                        if (notification[coordinates[idx]] !== 'Success') {
+                            return (<p key={idx}>Region {coordinates[idx]} {notification[coordinates[idx]]}</p>);
                         }
+                        return null;
                     })}
 
                 </div>
@@ -85,7 +87,7 @@ class RegulomeSummary extends React.Component {
             </div>
         );
     }
-}
+};
 
 RegulomeSummary.propTypes = {
     context: PropTypes.object.isRequired,

--- a/src/encoded/static/components/regulome_summary.js
+++ b/src/encoded/static/components/regulome_summary.js
@@ -3,36 +3,35 @@ import PropTypes from 'prop-types';
 import * as globals from './globals';
 import { SortTablePanel, SortTable } from './sorttable';
 
+const snpsColumns = {
+    chrom: {
+        title: 'Chromosome location',
+        display: (item) => {
+            const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+            return <a href={hrefScore}>{`${item.chrom}:${item.start}..${item.end}`}</a>;
+        },
+    },
+    rsids: {
+        title: 'dbSNP IDs',
+        display: (item) => {
+            const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+            return <a href={hrefScore}>{item.rsids.join(', ')}</a>;
+        },
+    },
+    regulome_score: {
+        title: 'Regulome score',
+        display: (item) => {
+            const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+            if (item.regulome_score !== 'N/A' && item.regulome_score !== null) {
+                return <a href={hrefScore}>{item.regulome_score}</a>;
+            }
+            return <a href={hrefScore}>See related experiments</a>;
+        },
+    },
+};
 
 const SNPSummary = (props) => {
     const snps = props.context.summaries;
-
-    const snpsColumns = {
-        chrom: {
-            title: 'Chromosome location',
-            display: (item) => {
-                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
-                return <a href={hrefScore}>{`${item.chrom}:${item.start}..${item.end}`}</a>;
-            },
-        },
-        rsids: {
-            title: 'dbSNP IDs',
-            display: (item) => {
-                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
-                return <a href={hrefScore}>{item.rsids.join(', ')}</a>;
-            },
-        },
-        regulome_score: {
-            title: 'Regulome score',
-            display: (item) => {
-                const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
-                if (item.regulome_score !== 'N/A' && item.regulome_score !== null) {
-                    return <a href={hrefScore}>{item.regulome_score}</a>;
-                }
-                return <a href={hrefScore}>See related experiments</a>;
-            },
-        },
-    };
     return (
         <div>
             <SortTablePanel title="Summary of SNP analysis">

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1046,7 +1046,7 @@ export class FacetList extends React.Component {
         // First we will check to see if there is an "assay_term_name" facet
         const assayFacet = facets.find(facet => facet.field === 'assay_term_name');
         // Then we will check to make sure that there is at least one "assay_term_name" term with "doc_count" greater than 0
-        const assayTerms = assayFacet ? assayFacet.terms.some(f => f.doc_count > 0) : false;
+        const assayTerms = assayFacet && assayFacet.terms.some(f => f.doc_count > 0);
 
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -12,7 +12,7 @@ import { FetchedData, Param } from './fetched';
 import GenomeBrowser from './genome_browser';
 import * as globals from './globals';
 import { Attachment } from './image';
-import { BrowserSelector, DisplayAsJson, requestSearch, DocTypeTitle } from './objectutils';
+import { BrowserSelector, DisplayAsJson, requestSearch } from './objectutils';
 import { DbxrefList } from './dbxref';
 import Status from './status';
 import { BiosampleSummaryString, BiosampleOrganismNames } from './typeutils';
@@ -622,7 +622,7 @@ function countSelectedTerms(terms, facet, filters) {
 
 // Display one term within a facet.
 const Term = (props) => {
-    const { filters, facet, total, canDeselect, searchBase, onFilter, statusFacet } = props;
+    const { filters, facet, total, canDeselect, searchBase, onFilter } = props;
     const term = props.term.key;
     const count = (props.term.doc_count > 999) ? props.term.doc_count.toPrecision(3) : props.term.doc_count;
     const title = props.title || term;
@@ -654,7 +654,7 @@ const Term = (props) => {
         href = `${searchBase}${field}=${globals.encodedURIComponent(term)}`;
         negationHref = `${searchBase}${field}!=${globals.encodedURIComponent(term)}`;
     }
-    
+
     const fieldVar = field === 'status' ? 'statusField' : field;
 
     return (
@@ -666,7 +666,7 @@ const Term = (props) => {
                     {(!selected && !negated) ? <i className="icon icon-square-o" /> : null}
                     {em ? <em>{title}</em> : <span>{title}</span>}
                 </div>
-                {negated ? null : <div className="facet-term__count">{(count < 1000) ? count : count/1000+"k"}</div>}
+                {negated ? null : <div className="facet-term__count">{(count < 1000) ? count : `${count / 1000}k`}</div>}
                 {(selected || negated) ? null : <div className="facet-term__bar" style={barStyle} />}
             </a>
             <div className="facet-term__negator">
@@ -685,14 +685,12 @@ Term.propTypes = {
     canDeselect: PropTypes.bool,
     searchBase: PropTypes.string.isRequired, // Base URI for the search
     onFilter: PropTypes.func,
-    statusFacet: PropTypes.bool, // True if the facet displays statuses
 };
 
 Term.defaultProps = {
     title: '',
     canDeselect: true,
     onFilter: null,
-    statusFacet: false,
 };
 
 
@@ -715,43 +713,40 @@ TypeTerm.propTypes = {
     total: PropTypes.number.isRequired,
 };
 
-export class FilterList extends React.Component {
-    
-    constructor(){
-        super();
+// Display list of selected filters
+export const FilterList = (props) => {
+    const filters = props.context.filters;
+    const negationFilters = filters.map(filter => filter.field.charAt(filter.field.length - 1) === '!');
+
+    if (filters.length > 0 && filters.length < 15) {
+        return (
+            <div className="filter-container">
+                <div className="filter-hed">Selected filters:</div>
+                {filters.map((filter, filterIdx) =>
+                    <a href={filter.remove} key={filter.term} className={negationFilters[filterIdx] ? 'negationFilter' : ''}><div className="filter-link"><i className="icon icon-times-circle" /> {filter.term}</div></a>
+                )}
+            </div>
+        );
     }
-    
-    render() {
-        const filters = this.props.context.filters;
-        const context = this.props.context;
-        const negationFilters = filters.map(filter => filter.field.charAt(filter.field.length - 1) === '!');
-        
-        if (filters.length > 0 && filters.length < 15) {
-            
-            return(
-                <div className="filter-container">
-                    <div className="filter-hed">Selected filters:</div>
-                    {filters.map((filter, filterIdx) =>
-                        <a href={filter.remove} key={filter.term} className={negationFilters[filterIdx] ? "negationFilter" : ""}><div className="filter-link"><i className="icon icon-times-circle" /> {filter.term}</div></a>
-                    )}
-                </div>
-            );
-        } 
-        
-        return null;
-    };
+    return null;
+};
+
+FilterList.propTypes = {
+    context: PropTypes.object.isRequired,
 };
 
 // Display header of facet list
 const FacetLabel = (props) => {
-    if (props.termHeader === 0 || props.link !== props.termHeader){
-        if (props.link === undefined) {
-            return <div className="facet-label experiments">Experiments</div>;
-        } else if (props.link === "annotation_type"){
-            return <div className="facet-label annotations">Annotations</div>;
-        }
+    if (props.label === 'assay_term_name') {
+        return <div className="facet-label experiments">Experiments</div>;
+    } else if (props.label === 'annotation_type') {
+        return <div className="facet-label annotations">Annotations</div>;
     }
     return null;
+};
+
+FacetLabel.propTypes = {
+    label: PropTypes.string.isRequired,
 };
 
 class Facet extends React.Component {
@@ -772,7 +767,7 @@ class Facet extends React.Component {
     }
 
     render() {
-        const { facet, filters } = this.props;
+        const { facet, filters, assayTerms } = this.props;
         const title = facet.title;
         const field = facet.field;
         const total = facet.total;
@@ -824,20 +819,31 @@ class Facet extends React.Component {
                 titleComponent = <span>{title}</span>;
             }
         }
-        
+
         // if ((terms.length && terms.some(term => term.doc_count))) {
         if ((terms.length && terms.some(term => term.doc_count)) || (field.charAt(field.length - 1) === '!')) {
             return (
-                <div className="facet">
-                    <h5>{titleComponent}</h5>
+                <div className={`facet facet${facet.field.replace('/ /g', '')}`}>
+                    { (field === 'annotation_type' || field === 'assay_term_name') ?
+                        <div>
+                            { (field === 'assay_term_name' || assayTerms === false) ?
+                                <div>
+                                    <h5>{titleComponent}</h5>
+                                    <FacetLabel label={field} />
+                                </div>
+                            :
+                                <FacetLabel label={field} />
+                            }
+
+                        </div>
+                    :
+                        <h5>{titleComponent}</h5>
+                    }
                     <ul className={`facet-list nav${statusFacet ? ' facet-status' : ''}`}>
                         <div>
                             {/* Display the first five terms of the facet */}
-                            {terms.slice(0, 5).map((term,termIdx) =>
+                            {terms.slice(0, 5).map(term =>
                                 <div key={term.key} >
-                                    {(field === "assay_term_name") ? 
-                                        <FacetLabel {...this.props} field={field} link={term.linkKey} termHeader={(termIdx===0) ? termIdx : terms[termIdx-1]["linkKey"] }/>
-                                    : null}
                                     <TermComponent {...this.props} term={term} filters={filters} total={total} canDeselect={canDeselect} statusFacet={statusFacet} />
                                 </div>
                             )}
@@ -846,10 +852,10 @@ class Facet extends React.Component {
                             <div id={termID} className={moreSecClass}>
                                 {/* If the user has expanded the "+ See more" button, then display
                                      the rest of the terms beyond 5 */}
-                                {moreTerms.map((term,termIdx) =>
+                                {moreTerms.map(term =>
                                     <div key={term.key} >
-                                        {(field === "assay_term_name") ? 
-                                            <FacetLabel {...this.props} field={field} link={term.linkKey} termHeader={terms[termIdx+5-1]["linkKey"] }/>
+                                        {(field === 'assay_term_name') ?
+                                            <FacetLabel label={field} />
                                         : null}
                                         <TermComponent {...this.props} term={term} filters={filters} total={total} canDeselect={canDeselect} statusFacet={statusFacet} />
                                     </div>
@@ -877,10 +883,7 @@ class Facet extends React.Component {
 Facet.propTypes = {
     facet: PropTypes.object.isRequired,
     filters: PropTypes.array.isRequired,
-};
-
-Facet.defaultProps = {
-    width: 'inherit',
+    assayTerms: PropTypes.bool.isRequired,
 };
 
 
@@ -974,39 +977,27 @@ TextFilter.propTypes = {
 // Displays the entire list of facets. It contains a number of <Facet> cmoponents.
 /* eslint-disable react/prefer-stateless-function */
 export class FacetList extends React.Component {
-    
     shouldComponentUpdate(nextProps) {
-        console.log("should the facet list update?");
-        console.log(!_.isEqual(this.props, nextProps));
         return !_.isEqual(this.props, nextProps);
     }
-    
+
     render() {
         const { context, facets, filters, mode, orientation, hideTextFilter, addClasses, modifyFacetsFlag } = this.props;
-        
-        let facetsModified = facets;
-        if (modifyFacetsFlag){
-            console.log("we are modifying the facets for regulome results");
-            // eliminate facets that we do not want to enable search for
-            facetsModified = facets.filter( facet => (facet.field !== 'files.file_type' && facet.field !=='status' && facet.field !== 'replicates.library.biosample.donor.organism.scientific_name' && facet.field !== 'assembly' && facet.field !== 'annotation_type'));
-        
-            // this is an extremely long-winded approach but my more abbreviated attempts did not work
-            facetsModified[0].terms = facets[0].terms;
-            facets[1].terms.forEach(function(f){
-                let flag = 0;
-                facets[0].terms.forEach(function(ff){
-                    if (f === ff){
-                        flag = 1;
-                    }
-                });
-                if (flag === 0){
-                    f.linkKey = 'annotation_type';
-                    facetsModified[0].terms.push(f);
-                }
-            });
-        
-            facetsModified[0].title = 'Method';
-            facetsModified[1].title = 'Biosample';
+
+        const facetsModified = facets;
+        if (modifyFacetsFlag) {
+            const methodIndex = facetsModified.map(facet => facet.title).indexOf('Assay');
+            if (methodIndex > -1) {
+                facetsModified[methodIndex].title = 'Method';
+            }
+            const annotationIndex = facetsModified.map(facet => facet.title).indexOf('Annotation type');
+            if (annotationIndex > -1) {
+                facetsModified[annotationIndex].title = 'Method';
+            }
+            const biosampleIndex = facetsModified.map(facet => facet.title).indexOf('Biosample term');
+            if (biosampleIndex > -1) {
+                facetsModified[biosampleIndex].title = 'Biosample';
+            }
         }
 
         // Get "normal" facets, meaning non-audit facets.
@@ -1050,10 +1041,9 @@ export class FacetList extends React.Component {
         // are the negation facet terms that need to get merged into the regular facets that their
         // non-negated versions inhabit.
         const negationFilters = filters.filter(filter => filter.field.charAt(filter.field.length - 1) === '!');
-        
-        console.log("building facets");
-        
-        console.log(width);
+
+        // If there are no assay terms, the annotation type facet will need the "Method" label
+        const assayTerms = facets.filter(facet => facet.field === 'assay_term_name').some(facet => facet.terms.some(f => f.doc_count > 0));
 
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
@@ -1071,6 +1061,7 @@ export class FacetList extends React.Component {
                                 filters={filters}
                                 width={width}
                                 negationFilters={negationFilters}
+                                assayTerms={assayTerms}
                             />
                         );
                     })}
@@ -1093,6 +1084,7 @@ FacetList.propTypes = {
     hideTextFilter: PropTypes.bool,
     docTypeTitleSuffix: PropTypes.string,
     addClasses: PropTypes.string, // CSS classes to use if the default isn't needed.
+    modifyFacetsFlag: PropTypes.bool,
 };
 
 FacetList.defaultProps = {
@@ -1102,6 +1094,7 @@ FacetList.defaultProps = {
     hideTextFilter: false,
     addClasses: '',
     docTypeTitleSuffix: 'search',
+    modifyFacetsFlag: false,
 };
 
 FacetList.contextTypes = {
@@ -1185,7 +1178,6 @@ BatchDownload.propTypes = {
 BatchDownload.defaultProps = {
     context: null,
     query: '',
-    downloadClickHandler: null,
 };
 
 BatchDownload.contextTypes = {
@@ -1525,7 +1517,6 @@ ResultTableList.defaultProps = {
 // Display a local genome browser in the ResultTable where search results would normally go. This
 // only gets displayed if the query string contains only one type and it's "File."
 export const ResultBrowser = (props) => {
-
     let visUrl = '';
     const datasetCount = props.datasets.length;
     let region = props.region; // optionally make a persistent region

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -986,15 +986,15 @@ export class FacetList extends React.Component {
 
         const facetsModified = facets;
         if (modifyFacetsFlag) {
-            const methodIndex = facetsModified.map(facet => facet.title).indexOf('Assay');
+            const methodIndex = facetsModified.findIndex(facet => facet.title === 'Assay');
             if (methodIndex > -1) {
                 facetsModified[methodIndex].title = 'Method';
             }
-            const annotationIndex = facetsModified.map(facet => facet.title).indexOf('Annotation type');
+            const annotationIndex = facetsModified.findIndex(facet => facet.title === 'Annotation type');
             if (annotationIndex > -1) {
                 facetsModified[annotationIndex].title = 'Method';
             }
-            const biosampleIndex = facetsModified.map(facet => facet.title).indexOf('Biosample term');
+            const biosampleIndex = facetsModified.findIndex(facet => facet.title === 'Biosample term');
             if (biosampleIndex > -1) {
                 facetsModified[biosampleIndex].title = 'Biosample';
             }
@@ -1043,7 +1043,10 @@ export class FacetList extends React.Component {
         const negationFilters = filters.filter(filter => filter.field.charAt(filter.field.length - 1) === '!');
 
         // If there are no assay terms, the annotation type facet will need the "Method" label
-        const assayTerms = facets.filter(facet => facet.field === 'assay_term_name').some(facet => facet.terms.some(f => f.doc_count > 0));
+        // First we will check to see if there is an "assay_term_name" facet
+        const assayFacet = facets.find(facet => facet.field === 'assay_term_name');
+        // Then we will check to make sure that there is at least one "assay_term_name" term with "doc_count" greater than 0
+        const assayTerms = assayFacet ? assayFacet.terms.some(f => f.doc_count > 0) : false;
 
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -479,6 +479,10 @@ div.meta-status {
     }
 }
 
+.facetassay_term_name {
+    border-bottom: 0;
+}
+
 .fade-out-pull-right {
     width: 100%;
     background-image: linear-gradient(to bottom, transparent, #F2F2F2);

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -131,8 +131,13 @@ body {
         .example-input {
             color: $regulomeGreen;
             text-decoration: underline;
+            padding: 0;
+            margin: 0 4px;
+            border: 0;
+            background: none;
             &:hover {
                 cursor: pointer;
+                font-weight: 600;
             }
         }
     }

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -256,6 +256,7 @@ dl.key-value {
         }
         h4 {
             font-size: 1.2rem;
+            line-height: normal;
             font-weight: normal;
             text-transform: uppercase;
             padding-top: 10px;


### PR DESCRIPTION
Previously when you would select an annotation term to filter results, the bars on the other annotation terms would overflow.
This resulted from two facets being combined ("assay_term_name" and "annotation_type"). Now, the facets are not combined, they are just designed to look like they are combined, and this resolves the issue.
Other updates on this branch are to fix linting errors.