### PR TITLE
REG-83 fix overlapping icons

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_tables.scss
+++ b/src/encoded/static/scss/encoded/modules/_tables.scss
@@ -192,6 +192,11 @@ form.table-filter {
                     width: 100%;
                     height: 100%;
                 }
+                .file-table-accession {
+                    a {
+                        width: auto;
+                    }
+                }
             }
 
             &.file-restricted {


### PR DESCRIPTION
Download icons were overflowing on File Details table.