### PR TITLE
REG-92 fix clickable FAQ for Safari and Firefox

### DIFF
--- a/src/encoded/static/components/blocks/richtext.js
+++ b/src/encoded/static/components/blocks/richtext.js
@@ -60,29 +60,27 @@ export default class RichTextBlockView extends React.Component {
 
     // Clickable FAQs: hide and show answers corresponding to questions
     handleClickableFAQ() {
-        if (this.state.value.body.includes('faq')) {
-            const faqContainer = document.getElementsByClassName('faq')[0];
-            // One event listener on the 'faq' container handles all click events
-            faqContainer.addEventListener('click', (e) => {
-                // Determine which question the user clicked on
-                const target = e.target.closest('.faq-question');
-                if (target) {
-                    // Toggle whether corresponding answer is displayed or hidden
-                    const infoId = target.id.split('faq')[1].split('-question')[0];
-                    const infoElement = document.getElementById(`faq${infoId}-answer`);
-                    infoElement.classList.toggle('show');
-                    // Toggle direction caret is pointing
-                    const iconElement = target.getElementsByTagName('i')[0];
-                    if (iconElement.className.indexOf('icon-caret-right') > -1) {
-                        iconElement.classList.add('icon-caret-down');
-                        iconElement.classList.remove('icon-caret-right');
-                    } else {
-                        iconElement.classList.remove('icon-caret-down');
-                        iconElement.classList.add('icon-caret-right');
-                    }
+        const faqContainer = document.getElementsByClassName('faq')[0];
+        // One event listener on the 'faq' container handles all click events
+        faqContainer.addEventListener('click', (e) => {
+            // Determine which question the user clicked on
+            const target = e.target.closest('.faq-question');
+            if (target) {
+                // Toggle whether corresponding answer is displayed or hidden
+                const infoId = target.id.split('faq')[1].split('-question')[0];
+                const infoElement = document.getElementById(`faq${infoId}-answer`);
+                infoElement.classList.toggle('show');
+                // Toggle direction caret is pointing
+                const iconElement = target.getElementsByTagName('i')[0];
+                if (iconElement.className.indexOf('icon-caret-right') > -1) {
+                    iconElement.classList.add('icon-caret-down');
+                    iconElement.classList.remove('icon-caret-right');
+                } else {
+                    iconElement.classList.remove('icon-caret-down');
+                    iconElement.classList.add('icon-caret-right');
                 }
-            });
-        }
+            }
+        });
     }
 
     render() {

--- a/src/encoded/static/components/blocks/richtext.js
+++ b/src/encoded/static/components/blocks/richtext.js
@@ -58,32 +58,31 @@ export default class RichTextBlockView extends React.Component {
         });
     }
 
+    // Clickable FAQs: hide and show answers corresponding to questions
     handleClickableFAQ() {
-        document.getElementsByClassName("faq")[0].addEventListener("click", function(e) {
-            let target = null;
-            for (let i = 0; i < e.path.length; i++) {
-                let tempPath = e.path[i].className;
-                if (tempPath){
-                   if (tempPath.indexOf("regulomehelp-question") !== -1) {
-                        target = e.path[i];
-                        break;
+        if (this.state.value.body.includes('faq')) {
+            const faqContainer = document.getElementsByClassName('faq')[0];
+            // One event listener on the 'faq' container handles all click events
+            faqContainer.addEventListener('click', (e) => {
+                // Determine which question the user clicked on
+                const target = e.target.closest('.faq-question');
+                if (target) {
+                    // Toggle whether corresponding answer is displayed or hidden
+                    const infoId = target.id.split('faq')[1].split('-question')[0];
+                    const infoElement = document.getElementById(`faq${infoId}-answer`);
+                    infoElement.classList.toggle('show');
+                    // Toggle direction caret is pointing
+                    const iconElement = target.getElementsByTagName('i')[0];
+                    if (iconElement.className.indexOf('icon-caret-right') > -1) {
+                        iconElement.classList.add('icon-caret-down');
+                        iconElement.classList.remove('icon-caret-right');
+                    } else {
+                        iconElement.classList.remove('icon-caret-down');
+                        iconElement.classList.add('icon-caret-right');
                     }
                 }
-            }
-            if (target !== null) {
-                let infoId = target.id.split("regulomehelp-faq")[1].split("-question")[0];
-                let infoElement = document.getElementById("regulomehelp-faq"+infoId+"-answer");
-                infoElement.classList.toggle("show");
-                let iconElement = e.target.getElementsByTagName("i")[0];
-                if (e.target.getElementsByTagName("i")[0].className.indexOf("icon-caret-right") > -1){
-                     iconElement.classList.add("icon-caret-down");
-                     iconElement.classList.remove("icon-caret-right");
-                } else {
-                     iconElement.classList.remove("icon-caret-down");
-                     iconElement.classList.add("icon-caret-right");
-                }
-            }
-        });
+            });
+        }
     }
 
     render() {


### PR DESCRIPTION
I was detecting which question a user had clicked on using a method only available in Chrome. This solution should be compatible with all browsers!