### PR TITLE
REG-98 update regulome facets

### DIFF
--- a/src/encoded/helpers/helper.py
+++ b/src/encoded/helpers/helper.py
@@ -82,7 +82,7 @@ def search_result_actions(request, doc_types, es_results, position=None):
     # generate batch download URL for experiments
     # TODO we could enable them for Datasets as well here, but not sure how well it will work
     # batch download disabled for region-search results
-    if '/region-search/' not in request.url:
+    if ('/region-search/' not in request.url) and ('/regulome-search/' not in request.url):
         #if (doc_types == ['Experiment'] or doc_types == ['Annotation']) and any(
         if (doc_types == ['Experiment']) and any(
                 bucket['doc_count'] > 0

--- a/src/encoded/regulome_search.py
+++ b/src/encoded/regulome_search.py
@@ -40,15 +40,11 @@ _ENSEMBL_URL_GRCH37 = 'http://grch37.rest.ensembl.org/'
 _REGULOME_FACETS = [
     ('assay_term_name', {'title': 'Assay'}),
     ('annotation_type', {'title': 'Annotation type'}),
-    ('status', {'title': 'Status'}),
-    ('biosample_term_name', {'title': 'Biosample term', 'type': 'typeahead'}),
+    ('biosample_ontology.classification', {'title': 'Biosample classification'}),
+    ('biosample_ontology.term_name', {'title': 'Biosample term name', 'type': 'typeahead'}),
     ('target.label', {'title': 'Target', 'type': 'typeahead', 'length': 'long'}),
-    ('replicates.library.biosample.donor.organism.scientific_name', {
-        'title': 'Organism'
-    }),
     ('organ_slims', {'title': 'Organ', 'type': 'typeahead'}),
     ('assembly', {'title': 'Genome assembly'}),
-    ('files.file_type', {'title': 'Available data'})
 ]
 
 _GENOME_TO_SPECIES = {

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -325,7 +325,7 @@ class RegulomeSearch extends React.Component {
         const notification = context.notification;
         const searchBase = url.parse(this.context.location_href).search || '';
         const filters = context.filters;
-        const facets = context.facets;
+        const facets = context.facets.filter(facet => facet.title !== "Genome assembly");;
         const total = context.total;
         const visualizeDisabled = total > visualizeLimit;
 

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -325,7 +325,7 @@ class RegulomeSearch extends React.Component {
         const notification = context.notification;
         const searchBase = url.parse(this.context.location_href).search || '';
         const filters = context.filters;
-        const facets = context.facets.filter(facet => facet.title !== "Genome assembly");;
+        const facets = context.facets.filter(facet => facet.title !== 'Genome assembly');
         const total = context.total;
         const visualizeDisabled = total > visualizeLimit;
 


### PR DESCRIPTION
Genome assembly has to in facet (for elastic aggregation) at the backend because it's used later for making visualization links. We can change that behavior later when we got other visualization tools.