### PR TITLE
REG-91 chromatin visualization

### DIFF
--- a/src/encoded/static/components/__tests__/datacolor-test.js
+++ b/src/encoded/static/components/__tests__/datacolor-test.js
@@ -32,8 +32,8 @@ describe('DataColor Module', () => {
         });
 
         it('Wraps around the used color if more keys than colors', () => {
-            const testColors = dataColorsInstance.colorList(['primary cell'], { shade: 10 });
-            expect(testColors[0]).toEqual('#ffb41a');
+            const testColors = dataColorsInstance.colorList(['primary cell'], { tint: 0.1 });
+            expect(testColors[0]).toEqual('#ffa419');
         });
     });
 });

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1036,7 +1036,7 @@ class App extends React.Component {
                     {this.props.inline ? <script data-prop-name="inline" dangerouslySetInnerHTML={{ __html: this.props.inline }} /> : null}
                     {this.props.styles ? <link rel="stylesheet" href={this.props.styles} /> : null}
                     {newsHead(this.props, `${hrefUrl.protocol}//${hrefUrl.host}`)}
-                    <link href="https://fonts.googleapis.com/css?family=Khula:300,400,600,700" rel="stylesheet" />
+                    <link href="https://fonts.googleapis.com/css?family=Khula:300,400,600,700,800" rel="stylesheet" />
                 </head>
                 <body onClick={this.handleClick} onSubmit={this.handleSubmit}>
                     <script

--- a/src/encoded/static/components/datacolors.js
+++ b/src/encoded/static/components/datacolors.js
@@ -1,3 +1,6 @@
+import _ from 'underscore';
+
+
 // DataColors is a class for managing symbolic data colors throughout the app. Essentially it
 // statically maps data keys to colors consistently even when the data changes.
 //
@@ -21,41 +24,204 @@ const rootColorList = [
 ];
 
 
+/**
+ * Convert a CSS hex color to an object with the equivalent r, g, and b components as integers from
+ * 0 to 255.
+ * @param {string} color CSS hex color to convert
+ * @return {object} { r, g, b } values
+ */
+export const colorToTriple = (color) => {
+    const num = parseInt(color.slice(1), 16);
+    const r = num >> 16;
+    const g = (num >> 8) & 0x00FF;
+    const b = num & 0x0000FF;
+    return { r, g, b };
+};
+
+
+/**
+ * Convert an object with r, g, and b components into a 6-digit, zero-filled hex color string.
+ * @param {object} r, g, and b components with values from 0 to 255.
+ * @return {string} Equivalent hex color string
+ */
+export const tripleToColor = ({ r, g, b }) => {
+    const rgb = b | (g << 8) | (r << 16);
+    return `#${(0x1000000 + rgb).toString(16).slice(1)}`;
+};
+
+
+/**
+ * Convert an RGB color into the equivalent HSV color.
+ * @param {object} rgbTriple { r, g, b } values from 0 to 255
+ * @return {object} { h, s, v } values with h from 0 to 359, and s and v from 0 to 1
+ */
+export const rgbToHsv = (rgbTriple) => {
+    // This calculation requires normalized R, G, and B values from 0 to 1.
+    const r = rgbTriple.r / 255;
+    const g = rgbTriple.g / 255;
+    const b = rgbTriple.b / 255;
+
+    // Here begins the mathematical conversion process:
+    // https://www.rapidtables.com/convert/color/rgb-to-hsv.html
+    const cMin = Math.min(r, g, b);
+    const cMax = Math.max(r, g, b);
+    let h;
+    let s;
+    const v = cMax;
+    const delta = cMax - cMin;
+    if (cMax > 0) {
+        s = delta / cMax;
+        if (cMax === r) {
+            h = (g - b) / delta;
+        } else if (cMax === g) {
+            h = 2 + ((b - r) / delta);
+        } else { // cMax === r
+            h = 4 + ((r - g) / delta);
+        }
+
+        // Convert h from 0-1 to degrees 0-359.
+        h *= 60;
+        h += h < 0 ? 360 : 0;
+    } else {
+        // Pure black case: h, s, v all zero.
+        s = 0;
+        h = 0;
+    }
+    return { h, s, v };
+};
+
+
+/**
+ * Convert an HSV color into the equivalent RGB color.
+ * @param {object} hsvTriple { h, s, v } values with h from 0 to 359, and s and v from 0 to 1
+ * @return {object} {r, g, b} color from 0 to 255
+ */
+export const hsvToRgb = (hsvTriple) => {
+    const { s, v } = hsvTriple;
+    let r;
+    let g;
+    let b;
+
+    if (s > 0) {
+        // This begins the H sector-based conversion process.
+        // https://www.rapidtables.com/convert/color/hsv-to-rgb.html
+        const h = hsvTriple.h / 60;
+        const sectorH = Math.floor(h);
+        const fractionH = h - sectorH;
+        const p = v * (1 - s);
+        const q = v * (1 - (s * fractionH));
+        const t = v * (1 - (s * (1 - fractionH)));
+        switch (sectorH) {
+        case 0: // 0 <= H < 60 degrees
+            r = v;
+            g = t;
+            b = p;
+            break;
+        case 1: // 60 <= H < 120 degrees
+            r = q;
+            g = v;
+            b = p;
+            break;
+        case 2: // 120 <= H < 180 degrees
+            r = p;
+            g = v;
+            b = t;
+            break;
+        case 3: // 180 <= H < 240 degrees
+            r = p;
+            g = q;
+            b = v;
+            break;
+        case 4: // 240 <= H < 300 degrees
+            r = t;
+            g = p;
+            b = v;
+            break;
+        default: // 300 <= H < 360 degrees
+            r = v;
+            g = p;
+            b = q;
+            break;
+        }
+    } else {
+        // Achromatic case.
+        r = v;
+        g = v;
+        b = v;
+    }
+
+    // Convert RGB from normalized to 0-255 integers.
+    return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+};
+
+
+/**
+ * Conversions from a hex RGB color to the equivalent HSV triplet often repeats with the same hex
+ * color, so breaking it out lets us memoize the function. Don't need a hashing function as
+ * memoize uses the hex color string as the hash by default.
+ * @param {string} color Hex color to convert to an HSV triplet
+ * @return {object} { h, s, v } color triplet
+ */
+const rColorToHsvTriple = (color) => {
+    const rgbTriple = colorToTriple(color);
+    return rgbToHsv(rgbTriple);
+};
+
+const colorToHsvTriple = _.memoize(rColorToHsvTriple);
+
+
+/**
+ * Tint a hex color by a factor from 0 to 1 to generate a new hex color. The output color tends to
+ * have fewer repeated values than the input hex color, so the conversion from hsv to the output
+ * hex color doesn't get memoized.
+ * @param {string} color CSS color on which to apply a tint value
+ * @param {number} tintFactor 0 for no change to `color`, 1 for white, and all between
+ */
+export const tintColor = (color, tintFactor) => {
+    const hsvTriple = colorToHsvTriple(color);
+    const outHsvTriple = {};
+    outHsvTriple.h = hsvTriple.h;
+    outHsvTriple.s = hsvTriple.s * (1 - tintFactor);
+    outHsvTriple.v = hsvTriple.v + (tintFactor * (1 - hsvTriple.v));
+    const rgbTriple = hsvToRgb(outHsvTriple);
+    return tripleToColor(rgbTriple);
+};
+
+
+/**
+ * Test whether a color is light or not. If it's light, then using it as a background to text makes
+ * black text most readable. If it's not light, then white text would work better.
+ * @param {string} color CSS hex color to test
+ * @return {bool} True if `color` is a "light" color.
+ */
+export const isLight = (color) => {
+    const { r, g, b } = colorToTriple(color);
+
+    // YIQ equation from http://24ways.org/2010/calculating-color-contrast
+    const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+    return yiq > 128;
+};
+
+
 class DataColors {
     constructor(keys) {
-        if (keys && keys.length) {
+        if (keys && keys.length > 0) {
             this.keys = [...keys]; // Clone given array
         } else {
             this.keys = [];
         }
     }
 
-    // Darken or lighten the given hex color by the given percentage (integer).
-    // http://stackoverflow.com/questions/5560248/programmatically-lighten-or-darken-a-hex-color-or-rgb-and-blend-colors
-    static shadeColor(color, percent) {
-        const num = parseInt(color.slice(1), 16);
-        const amt = Math.round(2.55 * percent);
-        const R = (num >> 16) + amt;
-        const G = ((num >> 8) & 0x00FF) + amt;
-        const B = (num & 0x0000FF) + amt;
-
-        return (
-            `#${(0x1000000 + ((R < 255 ? (R < 1 ? 0 : R) : 255) * 0x10000) +
-                    ((G < 255 ? (G < 1 ? 0 : G) : 255) * 0x100) +
-                    (B < 255 ? (B < 1 ? 0 : B) : 255)).toString(16).slice(1)}`
-        );
-    }
-
     // Return an array of colors corresponding to the given array of keys.
     // You can pass optional options in the `options` object.
     //
     // options:
-    //     shade (Number): Percentage to lighten (positive number) or darken (negative number) each
+    //     tint (Number): Percentage to lighten (positive number) or darken (negative number) each
     //         color from the root colors given at DataColors instantiation. This is a signed
     //         integer -- do not pass a string with a "%" sign at the end.
     colorList(keys, options) {
         let colors = [];
-        if (keys && keys.length) {
+        if (keys && keys.length > 0) {
             // Map the given keys to colors consistently
             colors = keys.map((key) => {
                 let outColor;
@@ -66,13 +232,13 @@ class DataColors {
                 } else {
                     outColor = rootColorList[i % rootColorList.length];
                 }
-                return options && options.shade && options.shade !== 0 ? DataColors.shadeColor(outColor, options.shade) : outColor;
+                return options && options.tint && options.tint > 0 ? tintColor(outColor, options.tint) : outColor;
             });
         } else {
             // No keys provided, just provide the list of colors for the caller to use as needed,
-            // optionally modified by a shade value.
-            colors = (options && options.shade && options.shade !== 0) ?
-                rootColorList.map(color => DataColors.shadeColor(color, options.shade))
+            // optionally modified by a tint value.
+            colors = (options && options.tint && options.tint !== 0) ?
+                rootColorList.map(color => tintColor(color, options.tint))
             : rootColorList;
         }
         return colors;

--- a/src/encoded/static/components/motifs.js
+++ b/src/encoded/static/components/motifs.js
@@ -98,11 +98,11 @@ export class MotifElement extends React.Component {
                     {element.organ_slims ?
                         <p><span className="motif-label">Organ</span>{element.organ_slims.join(', ')}</p>
                     : null}
-                    {targetList ?
+                    {(targetList.length > 0) ?
                         <p><span className="motif-label">{targetListLabel}</span>{targetList.join(', ')}</p>
                     : null}
                     <p><span className="motif-label">Method</span>{element.method}</p>
-                    {element.biosample_ontology ?
+                    {(element.biosample_ontology && element.biosample_ontology.term_name && element.biosample_ontology.term_name.length > 0) ?
                         <p><span className="motif-label">Biosample</span>{element.biosample_ontology.term_name}</p>
                     : null}
                     {element.description && !(this.props.shortened) ?

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -5,7 +5,7 @@ import url from 'url';
 import * as globals from './globals';
 import { SortTablePanel, SortTable } from './sorttable';
 import { Motifs } from './motifs';
-import { BarChart, ChartList, ChartTable, mapChromatinNames } from './visualizations';
+import { BarChart, ChartList, ChartTable, lookupChromatinNames } from './visualizations';
 
 const dataTypeStrings = [
     {
@@ -37,7 +37,7 @@ const exampleEntries = [
 const dataColumnsChromatin = {
     value: {
         title: 'Chromatin state',
-        display: item => mapChromatinNames(item.value),
+        display: item => lookupChromatinNames(item.value),
     },
     peak: {
         title: 'Chromatin state window',

--- a/src/encoded/static/components/regulome_summary.js
+++ b/src/encoded/static/components/regulome_summary.js
@@ -21,7 +21,7 @@ const snpsColumns = {
     regulome_score: {
         title: 'Regulome score',
         display: (item) => {
-            const hrefScore = `../regulome-search/?region=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
+            const hrefScore = `../regulome-search/?regions=${item.chrom}:${item.start}-${item.end}&genome=GRCh37`;
             if (item.regulome_score.probability && item.regulome_score.ranking) {
                 return <a href={hrefScore}>{item.regulome_score.probability} (probability); {item.regulome_score.ranking} (ranking)</a>;
             }

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -1,5 +1,63 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ResultsTable } from './regulome_search';
+import { isLight } from './datacolors';
+
+export const mapChromatinNames = name => (
+    name.includes('TssAFlnk') ? 'Flanking Active TSS'
+    : name.includes('TssA') ? 'Active TSS'
+    : name.includes('TxFlnk') ? "Transcr. at gene 5' and 3'"
+    : name.includes('TxWk') ? 'Weak transcription'
+    : name.includes('Tx') ? 'Strong transcription'
+    : name.includes('EnhG') ? 'Genic enhancers'
+    : name.includes('EnhBiv') ? 'Bivalent Enhancer'
+    : name.includes('Enh') ? 'Enhancers'
+    : name.includes('ZNF/Rpts') ? 'ZNF genes & repeats'
+    : name.includes('Het') ? 'Heterochromatin'
+    : name.includes('TssBiv') ? 'Bivalent/Poised TSS'
+    : name.includes('BivFlnk') ? 'Flanking Bivalent TSS/Enh'
+    : name.includes('ReprPCWk') ? 'Weak Repressed PolyComb'
+    : name.includes('ReprPC') ? 'Repressed PolyComb'
+    : name.includes('Quies') ? 'Quiescent/Low'
+    : null
+);
+
+const colorChromatinState = chrom => (
+    chrom === 'Flanking Active TSS' ? 'rgba(255,69,0)'
+    : chrom === 'Active TSS' ? 'rgba(255,0,0)'
+    : chrom === "Transcr. at gene 5' and 3'" ? 'rgba(50,205,50)'
+    : chrom === 'Strong transcription' ? 'rgba(0,128,0)'
+    : chrom === 'Weak transcription' ? 'rgba(0,100,0)'
+    : chrom === 'Genic enhancers' ? 'rgba(194,225,5)'
+    : chrom === 'Enhancers' ? 'rgba(255,255,0)'
+    : chrom === 'ZNF genes & repeats' ? 'rgba(102,205,170)'
+    : chrom === 'Heterochromatin' ? 'rgba(138,145,208)'
+    : chrom === 'Bivalent/Poised TSS' ? 'rgba(205,92,92)'
+    : chrom === 'Flanking Bivalent TSS/Enh' ? 'rgba(233,150,122)'
+    : chrom === 'Bivalent Enhancer' ? 'rgba(189,183,107)'
+    : chrom === 'Repressed PolyComb' ? 'rgba(128,128,128)'
+    : chrom === 'Weak Repressed PolyComb' ? 'rgba(192,192,192)'
+    : chrom === 'Quiescent/Low' ? '#DADADA' // this should be white but white is not visible against a white background
+    : '#d2d2d2'
+);
+
+const initializedChromatinObject = {
+    'Active TSS': 0,
+    'Flanking Active TSS': 0,
+    "Transcr. at gene 5' and 3'": 0,
+    'Strong transcription': 0,
+    'Weak transcription': 0,
+    'Genic enhancers': 0,
+    Enhancers: 0,
+    'ZNF genes & repeats': 0,
+    Heterochromatin: 0,
+    'Bivalent/Poised TSS': 0,
+    'Flanking Bivalent TSS/Enh': 0,
+    'Bivalent Enhancer': 0,
+    'Repressed PolyComb': 0,
+    'Weak Repressed PolyComb': 0,
+    'Quiescent/Low': 0,
+};
 
 // Consideration: may want to add back axis labels but they are not used now
 function drawHorizontalChart(d3, svgBars, chartData, fillColor, chartWidth) {
@@ -56,7 +114,7 @@ function drawHorizontalChart(d3, svgBars, chartData, fillColor, chartWidth) {
     svgBars.selectAll('bar')
         .data(chartData)
         .enter().append('rect')
-        .style('fill', fillColor)
+        .style('fill', d => fillColor(d.key))
         .attr('x', d => xScale(d.key))
         .attr('width', xScale.bandwidth())
         .attr('y', d => yScale(+d.value))
@@ -179,12 +237,13 @@ export class BarChart extends React.Component {
 
     drawCharts(targetElement) {
         const d3 = this.d3;
-
-        const allData = this.props.data;
-        let data = allData;
-        const fakeFacets = [];
+        const data = this.props.data;
+        let fillColor;
+        let fakeFacets = [];
+        const sortedFakeFacets = [];
+        let chartDataOrig = [];
         if (this.props.dataFilter === 'chip') {
-            data = allData.filter(d => d.method === 'ChIP-seq');
+            fillColor = () => '#276A8E';
             data.forEach((d) => {
                 if (fakeFacets[d.targets]) {
                     fakeFacets[d.targets] += 1;
@@ -193,7 +252,7 @@ export class BarChart extends React.Component {
                 }
             });
         } else if (this.props.dataFilter === 'dnase') {
-            data = allData.filter(d => (d.method === 'FAIRE-seq' || d.method === 'DNase-seq'));
+            fillColor = () => '#276A8E';
             data.forEach((d) => {
                 if (fakeFacets[d.biosample_ontology.term_name]) {
                     fakeFacets[d.biosample_ontology.term_name] += 1;
@@ -201,18 +260,36 @@ export class BarChart extends React.Component {
                     fakeFacets[d.biosample_ontology.term_name] = 1;
                 }
             });
-        }
-        // sort the fake facets
-        const keys = Object.keys(fakeFacets);
-        keys.sort((a, b) => (fakeFacets[b] - fakeFacets[a]));
-        const sortedFakeFacets = [];
-        keys.forEach((key) => {
-            sortedFakeFacets.push({
-                key,
-                value: fakeFacets[key],
+        } else if (this.props.dataFilter === 'chromatin') {
+            fillColor = colorChromatinState;
+            fakeFacets = Object.assign({}, initializedChromatinObject);
+            data.forEach((d) => {
+                const newName = mapChromatinNames(d.value);
+                fakeFacets[newName] += 1;
             });
-        });
-        const chartDataOrig = sortedFakeFacets;
+            const keys = Object.keys(fakeFacets);
+            keys.forEach((key) => {
+                if (fakeFacets[key] > 0) {
+                    sortedFakeFacets.push({
+                        key,
+                        value: fakeFacets[key],
+                    });
+                }
+            });
+            chartDataOrig = sortedFakeFacets;
+        }
+        // only sort the bar chart data if it is not chromatin data
+        if (this.props.dataFilter !== 'chromatin') {
+            const keys = Object.keys(fakeFacets);
+            keys.sort((a, b) => (fakeFacets[b] - fakeFacets[a]));
+            keys.forEach((key) => {
+                sortedFakeFacets.push({
+                    key,
+                    value: fakeFacets[key],
+                });
+            });
+            chartDataOrig = sortedFakeFacets;
+        }
 
         // return subset of results if 'chartLimit' is defined
         let chartData = [];
@@ -222,7 +299,6 @@ export class BarChart extends React.Component {
             chartData = chartDataOrig;
         }
         const svgElement = d3.select(targetElement).append('svg');
-        const fillColor = '#276A8E';
         if (this.props.chartOrientation === 'horizontal') {
             drawHorizontalChart(d3, svgElement, chartData, fillColor, this.props.chartWidth);
         } else if (this.props.chartOrientation === 'vertical') {
@@ -262,12 +338,17 @@ BarChart.propTypes = {
     chartOrientation: PropTypes.string.isRequired,
 };
 
-function filterForBiosample(element, key) {
-    if (element.biosample_ontology) {
-        if (element.biosample_ontology.term_name) {
-            return element.biosample_ontology.term_name === key;
+function filterForKey(element, key, dataFilter) {
+    if (dataFilter === 'dnase') {
+        if (element.biosample_ontology) {
+            if (element.biosample_ontology.term_name) {
+                return element.biosample_ontology.term_name === key;
+            }
+            return false;
         }
         return false;
+    } else if (dataFilter === 'chromatin') {
+        return mapChromatinNames(element.value) === key;
     }
     return false;
 }
@@ -278,7 +359,7 @@ const sanitizedString = inputString => inputString.toLowerCase()
     .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
 
 // Display information on page as JSON formatted data
-export class ChartTable extends React.Component {
+export class ChartList extends React.Component {
     constructor(props, context) {
         super(props, context);
 
@@ -291,6 +372,7 @@ export class ChartTable extends React.Component {
             data: [],
             unsanitizedSearchTerm: '',
             searchTerm: '',
+            fillColor: undefined,
         };
 
         // Bind `this` to non-React methods.
@@ -354,13 +436,27 @@ export class ChartTable extends React.Component {
     drawCharts() {
         const data = this.props.data;
         const fakeFacets = [];
-        data.forEach((d) => {
-            if (fakeFacets[d.biosample_ontology.term_name]) {
-                fakeFacets[d.biosample_ontology.term_name] += 1;
-            } else {
-                fakeFacets[d.biosample_ontology.term_name] = 1;
-            }
-        });
+        let fillColor;
+        if (this.props.dataFilter === 'dnase') {
+            data.forEach((d) => {
+                if (fakeFacets[d.biosample_ontology.term_name]) {
+                    fakeFacets[d.biosample_ontology.term_name] += 1;
+                } else {
+                    fakeFacets[d.biosample_ontology.term_name] = 1;
+                }
+            });
+            fillColor = () => '#276A8E';
+        } else {
+            data.forEach((d) => {
+                const newName = mapChromatinNames(d.value);
+                if (fakeFacets[newName]) {
+                    fakeFacets[newName] += 1;
+                } else {
+                    fakeFacets[newName] = 1;
+                }
+            });
+            fillColor = colorChromatinState;
+        }
         // sort the fake facets
         const keys = Object.keys(fakeFacets);
         keys.sort((a, b) => (fakeFacets[b] - fakeFacets[a]));
@@ -385,6 +481,7 @@ export class ChartTable extends React.Component {
             chartMax,
             leftMargin,
             data,
+            fillColor,
         });
     }
 
@@ -447,12 +544,19 @@ export class ChartTable extends React.Component {
                                     <div
                                         className="bar"
                                         style={{
-                                            backgroundColor: '#276A8E',
+                                            backgroundColor: this.state.fillColor(d),
                                             height: '20px',
                                             width: `${barWidth}px`,
                                         }}
                                     />
-                                    <div className="bar-annotation">{this.state.chartData[d]}</div>
+                                    <div
+                                        className="bar-annotation"
+                                        style={{
+                                            color: `${isLight(this.state.fillColor(d)) ? 'black' : 'white'}`,
+                                        }}
+                                    >
+                                        {this.state.chartData[d]}
+                                    </div>
                                 </div>
                             </div>
                             <div
@@ -463,20 +567,26 @@ export class ChartTable extends React.Component {
                                 id={`barchart-table-${dKey}`}
                                 aria-labelledby={`barchart-button-${dKey}`}
                             >
-                                {this.state.data.filter(element => filterForBiosample(element, d)).map(d2 =>
+                                {this.state.data.filter(element => filterForKey(element, d, this.props.dataFilter)).map(d2 =>
                                     <div className="table-entry" key={`table-entry-${d2.dataset.split('/')[2]}`}>
                                         <p><a href={d2.dataset}>{d2.dataset.split('/')[2]}</a></p>
                                         <div className="inset-table-entries">
-                                            {d2.organ_slims ?
-                                                <p><span className="table-label">Organ</span>{d2.organ_slims.join(', ')}</p>
+                                            {d2.biosample_ontology.organ_slims ?
+                                                <p><span className="table-label">Organ</span>{d2.biosample_ontology.organ_slims.join(', ')}</p>
                                             : null}
                                             {d2.method ?
                                                 <p><span className="table-label">Method</span>{d2.method}</p>
                                             :
                                                 <p><span className="table-label">Method</span>{d2.method}</p>
                                             }
+                                            {d2.file ?
+                                                <p><span className="table-label">File</span>{d2.file}</p>
+                                            : null}
                                             {d2.biosample_ontology ?
                                                 <p><span className="table-label">Biosample</span>{d2.biosample_ontology.term_name}</p>
+                                            : null}
+                                            {(d2.chrom && this.props.dataFilter === 'chromatin') ?
+                                                <p><span className="table-label">Chromatin state window</span>{d2.chrom}:{d2.start}..{d2.end}</p>
                                             : null}
                                             {d2.description ?
                                                 <p><span className="table-label">Description</span>{d2.description}</p>
@@ -496,6 +606,335 @@ export class ChartTable extends React.Component {
     }
 }
 
+ChartList.propTypes = {
+    data: PropTypes.array.isRequired,
+    displayTitle: PropTypes.string.isRequired,
+    chartWidth: PropTypes.number.isRequired,
+    dataFilter: PropTypes.string.isRequired,
+};
+
+// Display heat map for chromatin states
+// Note: this was developed and then it was decided that this was the wrong way to visualize the data
+// Nonetheless it may be useful later
+export class HeatMap extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+
+        this.state = {
+            matrix: [],
+            chromatinStates: [],
+            biosampleList: [],
+        };
+
+        // Bind `this` to non-React methods.
+        this.generateChartMatrix = this.generateChartMatrix.bind(this);
+    }
+
+    componentDidMount() {
+        this.generateChartMatrix();
+    }
+
+    generateChartMatrix() {
+        const data = this.props.data;
+        const matrix = [];
+        const allChromatinStates = data.map(d => d.value);
+        const chromatinStates = Array.from(new Set(allChromatinStates));
+        const allBiosampleList = data.map(d => d.biosample_ontology.term_name).filter(b => b !== undefined);
+        const biosampleList = Array.from(new Set(allBiosampleList));
+        biosampleList.forEach((bio) => {
+            chromatinStates.forEach((chrom) => {
+                matrix.push({
+                    biosample: bio,
+                    chromatin: chrom,
+                    count: 0,
+                });
+            });
+        });
+        data.forEach((d) => {
+            const existingIdx = matrix.findIndex(m => m.chromatin === d.value && m.biosample === d.biosample_ontology.term_name);
+            if (existingIdx > -1) {
+                matrix[existingIdx].count += 1;
+            }
+        });
+        this.setState({
+            matrix,
+            chromatinStates,
+            biosampleList,
+        });
+    }
+
+    render() {
+        return (
+            <div className="matrix-container">
+                {!(this.props.thumbnail) ?
+                    <div className="organ-labels">
+                        {this.state.biosampleList.map(organ =>
+                            <div
+                                className="organ-label"
+                                key={`organ${organ.toLowerCase().replace(/ /g, '')}`}
+                            >{organ}
+                            </div>
+                        )}
+                    </div>
+                : null}
+                <div className="heatmap">
+                    <div
+                        className="inner-heatmap"
+                        style={{
+                            width: `${this.state.chromatinStates.length * 26}px`,
+                        }}
+                    >
+                        {this.state.matrix.map((m, midx) =>
+                            <div
+                                key={`matrix${midx}`}
+                                className="color-block"
+                                style={{
+                                    backgroundColor: colorChromatinState(m.chromatin, m.count),
+                                    // width: `${(1 / this.state.chromatinStates.length) * 100}%`,
+                                }}
+                            />
+                        )}
+                    </div>
+                </div>
+                {!(this.props.thumbnail) ?
+                    <div className="biosample-empty-space" />
+                : null}
+                {!(this.props.thumbnail) ?
+                    <div className="biosample-labels">
+                        {this.state.chromatinStates.map(chrom =>
+                            <div
+                                className="bio-label"
+                                key={`chrom${chrom.toLowerCase().replace(/ /g, '')}`}
+                                style={{
+                                    width: '26px',
+                                }}
+                            >
+                                <div className="label-text">{chrom}</div>
+                            </div>
+                        )}
+                    </div>
+                : null}
+            </div>
+        );
+    }
+}
+
+HeatMap.propTypes = {
+    data: PropTypes.array.isRequired,
+    thumbnail: PropTypes.bool.isRequired,
+};
+
+// Display information on page as JSON formatted data
+export class ChartTable extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+
+        this.state = {
+            chartData: [],
+            filteredChartData: [],
+            chartMax: 0,
+            leftMargin: 0,
+            data: [],
+            filteredData: [],
+            unsanitizedSearchTerm: '',
+            searchTerm: '',
+            selectedStates: [],
+        };
+
+        // Bind `this` to non-React methods.
+        this.drawCharts = this.drawCharts.bind(this);
+        this.handleClick = this.handleClick.bind(this);
+        this.handleSearch = this.handleSearch.bind(this);
+        this.clearSearch = this.clearSearch.bind(this);
+    }
+
+    componentDidMount() {
+        this.drawCharts();
+    }
+
+    handleClick(clickID) {
+        let modifiedSelectedStates;
+        if (this.state.selectedStates.includes(clickID)) {
+            modifiedSelectedStates = [...this.state.selectedStates];
+            modifiedSelectedStates.splice(modifiedSelectedStates.indexOf(clickID), 1);
+        } else {
+            modifiedSelectedStates = [...this.state.selectedStates, clickID];
+        }
+        this.setState(prevState => ({
+            selectedStates: modifiedSelectedStates,
+            filteredData: prevState.data.filter((d) => {
+                if (this.state.searchTerm === '') {
+                    return (modifiedSelectedStates.includes(sanitizedString(mapChromatinNames(d.value))));
+                }
+                if (d.biosample_ontology.term_name) {
+                    return (sanitizedString(mapChromatinNames(d.value)).includes(this.state.searchTerm) || sanitizedString(d.biosample_ontology.term_name).includes(this.state.searchTerm) || sanitizedString(d.biosample_ontology.organ_slims.join(', ')).includes(this.state.searchTerm)) && modifiedSelectedStates.includes(sanitizedString(mapChromatinNames(d.value)));
+                }
+                return (sanitizedString(mapChromatinNames(d.value)).includes(this.state.searchTerm)) && modifiedSelectedStates.includes(sanitizedString(mapChromatinNames(d.value)));
+            }),
+        }));
+    }
+
+    handleSearch(event) {
+        // Unsanitized search term entered by user for display
+        this.setState({ unsanitizedSearchTerm: event.target.value });
+        // Search term entered by the user
+        const filterVal = String(sanitizedString(event.target.value));
+        this.setState({ searchTerm: filterVal });
+        const filteredData = this.state.data.filter((d) => {
+            if (filterVal === '') {
+                return true;
+            }
+            if (d.biosample_ontology.term_name) {
+                return sanitizedString(mapChromatinNames(d.value)).includes(filterVal) || sanitizedString(d.biosample_ontology.term_name).includes(filterVal) ||
+                sanitizedString(d.biosample_ontology.organ_slims.join(', ')).includes(filterVal);
+            }
+            return sanitizedString(mapChromatinNames(d.value)).includes(filterVal);
+        });
+        const fakeFacets = Object.keys(this.state.chartData)
+            .reduce((obj, key) => {
+                obj[key] = 0;
+                return obj;
+            }, {});
+        const newSelectedStates = [];
+        filteredData.forEach((d) => {
+            fakeFacets[mapChromatinNames(d.value)] += 1;
+            const chromatinValue = sanitizedString(mapChromatinNames(d.value));
+            if (!newSelectedStates.includes(chromatinValue)) {
+                newSelectedStates.push(chromatinValue);
+            }
+        });
+        this.setState({
+            filteredData,
+            filteredChartData: fakeFacets,
+            selectedStates: newSelectedStates,
+        });
+    }
+
+    clearSearch() {
+        // clear both search terms
+        this.setState(prevState => ({
+            searchTerm: '',
+            unsanitizedSearchTerm: '',
+            filteredData: prevState.data.filter(d => (prevState.selectedStates.includes(sanitizedString(mapChromatinNames(d.value))))),
+            filteredChartData: prevState.chartData,
+        }));
+    }
+
+    drawCharts() {
+        const data = this.props.data;
+        const initialChartData = Object.assign({}, initializedChromatinObject);
+        data.forEach((d) => {
+            initialChartData[mapChromatinNames(d.value)] += 1;
+        });
+        const chartData = Object.keys(initialChartData)
+            .filter(key => initialChartData[key] > 0)
+            .reduce((obj, key) => {
+                obj[key] = initialChartData[key];
+                return obj;
+            }, {});
+        const chartKeys = Object.keys(chartData);
+        const chartArray = chartKeys.map(key => chartData[key]);
+        const chartMax = Math.max(...chartArray);
+        let selectedStates = [];
+        for (let idx = 0; idx < chartKeys.length; idx += 1) {
+            if (chartData[chartKeys[idx]] > 0) {
+                selectedStates = [sanitizedString(chartKeys[idx])];
+                break;
+            }
+        }
+        const filteredData = data.filter(d => (selectedStates.includes(sanitizedString(mapChromatinNames(d.value)))));
+        // compute left margin
+        let leftMargin = 60;
+        Object.keys(chartData).forEach((d) => {
+            leftMargin = Math.max(d.length * 7, leftMargin);
+        });
+        // add in some extra margin for white space and caret icon
+        leftMargin += 50;
+        this.setState({
+            chartData,
+            filteredChartData: chartData,
+            chartMax,
+            leftMargin,
+            data,
+            filteredData,
+            selectedStates,
+        });
+    }
+
+    render() {
+        const chartTitle = this.props.displayTitle;
+        return (
+            <div className="bar-chart-container bar-chart-chromatin">
+                <div className="bar-chart-header short">
+                    <h4>{chartTitle}</h4>
+                    <div className="chart-typeahead-container">
+                        <div className="chart-typeahead" role="search">
+                            <i className="icon icon-search" />
+                            <div className="searchform">
+                                <input type="search" aria-label="search to filter biosample results" placeholder="Search for a biosample name or chromatin state" value={this.state.unsanitizedSearchTerm} onChange={this.handleSearch} />
+                            </div>
+                            <i className="icon icon-times" aria-label="clear search and see all biosample results" onClick={this.clearSearch} onKeyDown={this.clearSearch} role="button" tabIndex="0" />
+                        </div>
+                    </div>
+                </div>
+                <div className="bar-chart-bars">
+                    {Object.keys(this.state.filteredChartData).map((d) => {
+                        const dKey = sanitizedString(d);
+                        const barWidth = ((this.props.chartWidth - this.state.leftMargin) / this.state.chartMax) * this.state.filteredChartData[d];
+                        const remainderWidth = this.props.chartWidth - barWidth - this.state.leftMargin;
+                        return (
+                            <div
+                                className={`biosample-table table${dKey} display-table`}
+                                key={`table${dKey}`}
+                            >
+                                <div className="bar-row" key={this.state.filteredChartData[d]}>
+                                    <button
+                                        className={`bar-label ${this.state.selectedStates.includes(dKey) ? 'active' : ''}`}
+                                        style={{
+                                            width: `${this.state.leftMargin}px`,
+                                        }}
+                                        onClick={() => this.handleClick(dKey)}
+                                        id={`barchart-button-${dKey}`}
+                                    >
+                                        {d}
+                                    </button>
+                                    <div
+                                        className="bar-container"
+                                        style={{
+                                            height: '22px',
+                                            width: `${barWidth}px`,
+                                            marginRight: `${remainderWidth}px`,
+                                        }}
+                                    >
+                                        <div
+                                            className="bar"
+                                            style={{
+                                                backgroundColor: colorChromatinState(d),
+                                                height: '22px',
+                                                width: `${barWidth}px`,
+                                            }}
+                                        />
+                                        <div
+                                            className="bar-annotation"
+                                            style={{
+                                                color: `${(isLight(colorChromatinState(d)) || d === 'Enhancers' || barWidth <= 20) ? 'black' : 'white'}`,
+                                                right: `${barWidth > 20 ? '5px' : '-12px'}`,
+                                            }}
+                                        >
+                                            {this.state.filteredChartData[d]}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+                <ResultsTable data={this.state.filteredData} displayTitle={''} dataFilter={'chromatin'} errorMessage={'Click on a chromatin state name or enter a different search term to see results.'} />
+            </div>
+        );
+    }
+}
+
 ChartTable.propTypes = {
     data: PropTypes.array.isRequired,
     displayTitle: PropTypes.string.isRequired,
@@ -504,5 +943,8 @@ ChartTable.propTypes = {
 
 export default {
     BarChart,
+    ChartList,
     ChartTable,
+    HeatMap,
+    mapChromatinNames,
 };

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -866,7 +866,6 @@ table {
 
 .notification {
     font-weight: 600;
-    text-transform: capitalize;
 }
 
 .notification-label-centered {

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -381,7 +381,6 @@ a {
 table {
     th,td {
         padding: 10px 10px 4px !important;
-        // border: 1px solid $regulomeGray;
     }
     td {
         a {
@@ -561,7 +560,7 @@ table {
     line-height: 1.1;
     margin-bottom: 1px;
     &.selected {
-        background: #DBEFFA;//#9dcbe4;
+        background: #DBEFFA;
         .facet-term__item {
             color: black;
         }
@@ -794,6 +793,9 @@ table {
             -moz-box-shadow: none;
             -webkit-box-shadow: none;
             box-shadow: none;
+            &:hover {
+                background: #CFCFCF;
+            }
             h4 {
                 font-size: 1.1rem;
                 margin-top: 0;
@@ -868,7 +870,6 @@ table {
 }
 
 .notification-label-centered {
-    // text-transform: uppercase;
     font-weight: 500;
     text-align: center;
     font-size: 16px;
@@ -916,7 +917,7 @@ button {
             font-size: 12px;
         }
         .bold-label {
-            font-weight: 800;
+            font-weight: 700;
             fill: rgb(193, 59, 66);
         }
     }
@@ -951,8 +952,7 @@ button {
         position: absolute;
         top: 2px;
         right: 5px;
-        color: white;
-        font-weight: 800;
+        font-weight: 700;
     }
 }
 
@@ -990,6 +990,9 @@ button {
         }
     }
     padding-bottom: 40px;
+    &.short {
+        padding-bottom: 20px;
+    }
 }
 .barchart-table {
     padding: 20px;
@@ -1064,4 +1067,85 @@ button {
     display: inline-block;
     max-width: 500px;
     width: 100%;
+}
+
+.matrix-container {
+    display: flex;
+    flex-wrap: wrap;
+    .heatmap {
+        display: flex;
+        flex-wrap: wrap;
+    }
+    .inner-heatmap {
+        display: flex;
+        flex-wrap: wrap;
+    }
+    .color-block {
+        height: 26px;
+        width: 26px;
+    }
+    .biosample-empty-space, .biosample-labels, .organ-labels, .heatmap {
+        flex: 0 0 50%;
+        width: 50%;
+    }
+    .organ-label {
+        height: 26px;
+        padding-top: 7px;
+        text-align: right;
+        padding-right: 10px;
+        line-height: 1;
+        &.tall {
+            padding-top: 0;
+        }
+    }
+    .biosample-labels {
+        line-height: 1;
+        .bio-label {
+            width: 20%;
+            height: 270px;
+            white-space: nowrap;
+            display: inline-block;
+            position: relative;
+        }
+        .label-text {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 32px;
+            line-height: 32px;
+            padding: 0 1em;
+            transform-origin: top left;
+            transform: rotate(-90deg) translateX(-100%);
+        }
+    }
+}
+
+.bar-chart-chromatin {
+    .bar-row .bar-label {
+        border-bottom: none;
+        padding-bottom: 4px;
+        font-weight: 700;
+        font-size: 1rem;
+        padding: 4px 10px 3px;
+        &:hover, &.active {
+            text-decoration: underline;
+            font-weight: 800;
+        }
+        &.active {
+            padding: 2px 10px 1px;
+            border: 2px solid;
+            font-weight: 700;
+            text-decoration: none;
+        }
+        &.active {
+            background: #ECECEC;
+        }
+    }
+    .bar {
+        margin-bottom: 0;
+    }
+}
+
+.bar-chart-bars {
+    margin-bottom: 40px;
 }


### PR DESCRIPTION
Note: two of the commits are from @yunhailuo's PR. This branch should be merged after his PR, and the changes from those commits do not need to be reviewed here.

This branch is for chromatin visualizations: it adds a bar chart on the chromatin thumbnail and an interactive table on the chromatin tab, where the table results are controlled by a search bar (searchable by organ, biosample, or chromatin state) and by a bar chart showing how many results correspond to each chromatin state. Unlike the other visualizations, the bar charts for chromatin are ordered by state, not by number of results.