### PR TITLE
REG-119 motif alignments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,7 +2408,7 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-sequence-logo": {
-      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#d1a37199e01c467b8fdc5f94b6b3a18d734495d6",
+      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#6d25a48ab9f7d6b0e695331dde77080f34339ae6",
       "from": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#REG-71-add-pwm-logos",
       "requires": {
         "d3": "^3.3.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,7 +2408,7 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-sequence-logo": {
-      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#f84a7206ff036c7fc444214a6be485dd46735764",
+      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#d1a37199e01c467b8fdc5f94b6b3a18d734495d6",
       "from": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#REG-71-add-pwm-logos",
       "requires": {
         "d3": "^3.3.8"

--- a/src/encoded/static/components/motifs.js
+++ b/src/encoded/static/components/motifs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import * as logos from '../libs/d3-sequence-logo'; // This is for local development when changes are needed to d3-sequence-logo.
+import * as logos from '../libs/d3-sequence-logo'; // This is for local development when changes are needed to d3-sequence-logo.
 
 // Convert PWM file into JavaScript object
 // Input "str" consists of PWM file
@@ -52,8 +52,8 @@ export class MotifElement extends React.Component {
     componentDidMount() {
         require.ensure(['d3', 'd3-sequence-logo'], (require) => {
             this.d3 = require('d3');
-            // this.sequenceLogos = logos; // This is for local development when changes are needed to d3-sequence-logo.
-            this.sequenceLogos = require('d3-sequence-logo');
+            this.sequenceLogos = logos; // This is for local development when changes are needed to d3-sequence-logo.
+            // this.sequenceLogos = require('d3-sequence-logo');
             const pwmLink = this.generatePWMLink();
 
             getMotifData(pwmLink, this.context.fetch).then((response) => {

--- a/src/encoded/static/components/motifs.js
+++ b/src/encoded/static/components/motifs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as logos from '../libs/d3-sequence-logo'; // This is for local development when changes are needed to d3-sequence-logo.
+// import * as logos from '../libs/d3-sequence-logo'; // This is for local development when changes are needed to d3-sequence-logo.
 
 // Convert PWM file into JavaScript object
 // Input "str" consists of PWM file
@@ -52,8 +52,8 @@ export class MotifElement extends React.Component {
     componentDidMount() {
         require.ensure(['d3', 'd3-sequence-logo'], (require) => {
             this.d3 = require('d3');
-            this.sequenceLogos = logos; // This is for local development when changes are needed to d3-sequence-logo.
-            // this.sequenceLogos = require('d3-sequence-logo');
+            // this.sequenceLogos = logos; // This is for local development when changes are needed to d3-sequence-logo.
+            this.sequenceLogos = require('d3-sequence-logo');
             const pwmLink = this.generatePWMLink();
 
             getMotifData(pwmLink, this.context.fetch).then((response) => {

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -788,7 +788,16 @@ class RegulomeSearch extends React.Component {
 
         return (
             <div ref={(ref) => { this.applicationRef = ref; }} >
-                {(context.total > 0) ?
+                { ((Object.keys(this.props.context.notifications)[0] === 'Failed') && context.total !== 0) ?
+                    <div>
+                        {Object.keys(this.props.context.notifications).map((note, noteIdx) =>
+                            <div className="notification-line wider" key={noteIdx}>
+                                <span className="notification-label">{note}</span>
+                                <span className="notification">{this.props.context.notifications[note]}</span>
+                            </div>
+                        )}
+                    </div>
+                : (context.total > 0) ?
                     <div>
                         <div className="lead-logo">
                             <a href="/">
@@ -910,7 +919,7 @@ class RegulomeSearch extends React.Component {
                                             <div className="line"><i className="icon icon-chevron-circle-right" />Click to see dsQTL and eQTL data.
                                                 <div>(<b>{QTLData.length}</b> result{QTLData.length !== 1 ? 's' : ''})</div>
                                             </div>
-                                            <ResultsTable data={QTLData} displayTitle={'dsQTL and eQTL data'} dataFilter={'qtl'} errorMessage={'No result table is available for this SNP.'} shortened />
+                                            <ResultsTable data={QTLData} displayTitle={''} dataFilter={'qtl'} errorMessage={'No result table is available for this SNP.'} shortened />
                                         </div>
                                     : null}
                                 </button>

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -89,6 +89,7 @@ function drawHorizontalChart(d3, svgBars, chartData, fillColor, chartWidth) {
 
     const chartArray = chartData.map(d => d.value);
     const chartMax = Math.max(...chartArray);
+    const tickNum = Math.min(chartMax, 4);
 
     svgBars
         .attr('width', chartWidth)
@@ -117,7 +118,7 @@ function drawHorizontalChart(d3, svgBars, chartData, fillColor, chartWidth) {
     svgBars.append('g')
         .attr('transform', `translate(${margin.left},0)`)
         .call(d3.axisLeft(yScale)
-            .ticks(4)
+            .ticks(tickNum)
             .tickFormat(d3.format('d')));
 
     svgBars.selectAll('bar')

--- a/src/encoded/static/libs/d3-sequence-logo.js
+++ b/src/encoded/static/libs/d3-sequence-logo.js
@@ -16,6 +16,11 @@
 
 const d3 = require('d3');
 
+// ordering for positive strand
+const positiveStrandLetterOrder = ['A', 'C', 'G', 'T'];
+// letter ordering for negative strand (reverse complement)
+const negativeStrandLetterOrder = ['T', 'G', 'C', 'A'];
+
 /**
  * For each index, get the transform needed so that things line up
  * correctly. This is an artifact of the font->svg path conversion
@@ -49,57 +54,21 @@ function getLetterBaseTransform(i) {
  * @returns {string} SVG path corresponding to i.
  */
 function getLetterPath(i, strand) {
-    const letterA = 'M142.59,54.29l-5,15.27h-6.48L147.55,21h7.56l16.56,48.53H165l-5.18-15.27Zm15.91-4.9-4.75-14c-1.08-3.17-1.8-6-2.52-8.86h-.14c-.72,2.88-1.51,5.83-2.45,8.78l-4.75,14Z';
+    const letterPaths = {};
+    letterPaths.A = 'M142.59,54.29l-5,15.27h-6.48L147.55,21h7.56l16.56,48.53H165l-5.18-15.27Zm15.91-4.9-4.75-14c-1.08-3.17-1.8-6-2.52-8.86h-.14c-.72,2.88-1.51,5.83-2.45,8.78l-4.75,14Z';
 
-    const letterG = 'M171.68,67.39a45.22,45.22,0,0,1-14.91,2.66c-7.34,0-13.39-1.87-18.15-6.41-4.18-4-6.77-10.51-6.77-18.07.07-14.47,10-25.06,26.28-25.06a30,30,0,0,1,12.1,2.23l-1.51,5.11A25.15,25.15,0,0,0,158,25.77c-11.81,0-19.51,7.34-19.51,19.51s7.42,19.59,18.72,19.59c4.1,0,6.91-.58,8.35-1.3V49.1h-9.86v-5h16Z';
+    letterPaths.G = 'M171.68,67.39a45.22,45.22,0,0,1-14.91,2.66c-7.34,0-13.39-1.87-18.15-6.41-4.18-4-6.77-10.51-6.77-18.07.07-14.47,10-25.06,26.28-25.06a30,30,0,0,1,12.1,2.23l-1.51,5.11A25.15,25.15,0,0,0,158,25.77c-11.81,0-19.51,7.34-19.51,19.51s7.42,19.59,18.72,19.59c4.1,0,6.91-.58,8.35-1.3V49.1h-9.86v-5h16Z';
 
-    const letterT = 'M144,26.35H129.19V21h35.93v5.33H150.29v43.2H144Z';
+    letterPaths.T = 'M144,26.35H129.19V21h35.93v5.33H150.29v43.2H144Z';
 
-    const letterC = 'M168.65,68c-2.3,1.15-6.91,2.3-12.82,2.3-13.68,0-24-8.64-24-24.55,0-15.19,10.3-25.49,25.35-25.49,6,0,9.86,1.3,11.52,2.16l-1.51,5.11a22.82,22.82,0,0,0-9.79-2c-11.38,0-18.94,7.27-18.94,20,0,11.88,6.84,19.51,18.65,19.51a25.08,25.08,0,0,0,10.23-2Z';
+    letterPaths.C = 'M168.65,68c-2.3,1.15-6.91,2.3-12.82,2.3-13.68,0-24-8.64-24-24.55,0-15.19,10.3-25.49,25.35-25.49,6,0,9.86,1.3,11.52,2.16l-1.51,5.11a22.82,22.82,0,0,0-9.79-2c-11.38,0-18.94,7.27-18.94,20,0,11.88,6.84,19.51,18.65,19.51a25.08,25.08,0,0,0,10.23-2Z';
 
     // if the strand is negative, we want the reverse complement
     if (strand === '-') {
-        if (i === 0) {
-            return letterT;
-        } else if (i === 1) {
-            return letterG;
-        } else if (i === 2) {
-            return letterC;
-        } else if (i === 3) {
-            return letterA;
-        }
-        return null;
+        return letterPaths[negativeStrandLetterOrder[i]];
     }
     // if the strand is positive, we do not need to get the reverse complement
-    if (i === 0) {
-        return letterA;
-    } else if (i === 1) {
-        return letterC;
-    } else if (i === 2) {
-        return letterG;
-    } else if (i === 3) {
-        return letterT;
-    }
-    return null;
-}
-
-/**
- * @param {string[]} s - sequence data. An array of equal-length strings.
- * @param {number} i - letter index. Range: [0,4)
- * @returns {number[]} counts of each letter.
- */
-function getLetterCnts(s, i) {
-    const dict = { A: 0,
-        C: 0,
-        G: 0,
-        T: 0 };
-
-    s.forEach((d) => {
-        dict[d[i]] += 1;
-    });
-
-    const out = Object.keys(dict).map(key => dict[key]);
-    return out;
+    return letterPaths[positiveStrandLetterOrder[i]];
 }
 
 /**
@@ -203,105 +172,6 @@ function calcPathTransform(path, d, yscale, colWidth) {
 }
 
 /**
- * Checks that sequence data obeys bounds, and that each
- * sequence has the same length.
- *
- * Possible change is to create more informative error msg.
- *
- * @param {string[]} data - sequenceData
- * @param {number[]} seqLenBounds - lower/upper bounds for
- *  number of bases in a sequence.
- * @param {number[]} seqNumBounds - lower/upper bounds for
- *  number of sequences.
- * @returns {boolean} true/false - does the data conform?
- */
-function isValidData(data, seqLenBounds, seqNumBounds) {
-    const n = data.length;
-
-    if (n > seqNumBounds[1] || n < seqNumBounds[0]) {
-        return false;
-    }
-    const m0 = d3.min(data, d => d.length);
-    const m1 = d3.max(data, d => d.length);
-
-    if (m0 !== m1) {
-        return false;
-    }
-    // m == m0 == m1
-    const m = m0;
-
-    if (m > seqLenBounds[1] || m < seqLenBounds[0]) {
-        return false;
-    }
-    return true;
-}
-
-/**
- * Yields nucleotide base string corresponding to given int.
- *
- * @param {number} i
- * @returns {string}
- */
-
-function intToLetter(i) {
-    if (i === 0) {
-        return 'A';
-    } else if (i === 1) {
-        return 'C';
-    } else if (i === 2) {
-        return 'G';
-    } else if (i === 3) {
-        return 'T';
-    }
-    return null;
-}
-
-/**
- * Standard, from MDN.
- * Returns a random integer between min (inclusive) and max
- * (inclusive)
- *
- * @param {number} min
- * @param {number} max
- * @returns {number}
- */
-function getRandomInt(min, max) {
-    return Math.floor(Math.random() * ((max - min) + 1)) + min;
-}
-
-
-/**
- * Generate random sequences by sampling from DiscreteUniform(0,4).
- *
- * A different approach could be to favor some bases more
- * than others at different positions by modeling the
- * distribution P(base | position) as a categorical that
- * has its parameters sampled from a Dirichlet.
- *
- * @param {number[]} seqLenBounds
- * @param {number[]} seqNumBounds
- * @returns {string[]} seqData
- */
-function getRandomData(seqLenBounds, seqNumBounds) {
-    const seqLen = getRandomInt(seqLenBounds[0], seqLenBounds[1]);
-    const seqNum = getRandomInt(seqNumBounds[0], seqNumBounds[1]);
-
-    const seqData = [];
-
-    for (let i = 0; i < seqNum; i += 1) {
-        const thisSeq = [];
-        for (let j = 0; j < seqLen; j += 1) {
-            // upper bound is inclusive (getRandomInt)
-            const newLetter = intToLetter(getRandomInt(0, 3));
-            thisSeq.push(newLetter);
-        }
-        seqData.push(thisSeq.join(''));
-    }
-
-    return seqData;
-}
-
-/**
  * Entry point for all functionality.
  *
  * @param {string[]} sequenceData
@@ -359,32 +229,21 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
     // height of just the base letters
     const svgLetterHeight = 150;
 
-    function colors(i) {
+    const colorBase = {
+        A: '#C13B42',
+        C: '#EFB549',
+        G: '#335C95',
+        T: '#489655',
+    };
+
+    const lookupBaseColor = (i) => {
         // if the strand is negative, we want the reverse complement
         if (strand === '-') {
-            if (i === 0) {
-                return '#489655';
-            } else if (i === 1) {
-                return '#335C95';
-            } else if (i === 2) {
-                return '#EFB549';
-            } else if (i === 3) {
-                return '#C13B42';
-            }
-            return null;
+            return colorBase[negativeStrandLetterOrder[i]];
         }
         // if the strand is positive, we do not need to get the reverse complement
-        if (i === 3) {
-            return '#489655';
-        } else if (i === 2) {
-            return '#335C95';
-        } else if (i === 1) {
-            return '#EFB549';
-        } else if (i === 0) {
-            return '#C13B42';
-        }
-        return null;
-    }
+        return colorBase[positiveStrandLetterOrder[i]];
+    };
 
     // map: sequence length -> innerSVG
     const xscale = d3.scaleLinear().domain([0, m])
@@ -495,7 +354,7 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
         .filter(d => (d[1] - d[0] > 0))
         .append('path')
         .attr('d', d => getLetterPath(d[2], strand))
-        .style('fill', d => colors(d[2]))
+        .style('fill', d => lookupBaseColor(d[2]))
         /* eslint-disable func-names */
         .attr('transform', function (d) { return calcPathTransform(this, d, yscale, colWidth); }); // This line cannot be an arrow function or 'this' will be improperly assigned
 
@@ -509,25 +368,6 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
         .attr('fill', 'none')
         .attr('stroke-width', '4px')
         .attr('transform', `translate(${xscale(alignmentIndex)},0)`);
-}
-
-/**
-* Get random sequence data, then call entry point.
-*
-* @param {number[]} seqLenBounds
-* @param {number[]} seqNumBounds
-*/
-function refreshSVG(seqLenBounds, seqNumBounds) {
-    const sequenceData = getRandomData(seqLenBounds, seqNumBounds);
-
-    // clear SVG if it exists
-    const svg = d3.select('svg');
-
-    if (svg) {
-        svg.remove();
-    }
-
-    entryPoint(sequenceData, seqLenBounds, seqNumBounds);
 }
 
 module.exports.entryPoint = entryPoint;

--- a/src/encoded/static/scss/encoded/modules/_regulome_motifs.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_motifs.scss
@@ -36,6 +36,14 @@
                 margin-right: 5px;
             }
         }
+        .icon-minus-circle, .icon-plus-circle {
+            color: #9F9F9F;
+        }
+        &.shortened-description {
+            .motif-label {
+                display: none;
+            }
+        }
     }
     border-bottom: 1px solid #ccc;
     &:first-child {

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -734,6 +734,7 @@ table {
     flex-wrap: wrap;
     align-items: stretch;
     justify-content: space-between;
+    margin-top: 15px;
     .thumbnail {
         flex: 0 0 32%;
         max-width: 32%;
@@ -960,6 +961,7 @@ button {
     svg {
         max-width: 100%;
         max-height: 90px;
+        overflow: visible;
         .domain {
             display: none;
         }

--- a/src/encoded/static/scss/fontawesome/_icons.scss
+++ b/src/encoded/static/scss/fontawesome/_icons.scss
@@ -87,7 +87,7 @@
 //.#{$fa-css-prefix}-eject:before { content: $fa-var-eject; }
 .#{$fa-css-prefix}-chevron-left:before { content: $fa-var-chevron-left; }
 .#{$fa-css-prefix}-chevron-right:before { content: $fa-var-chevron-right; }
-//.#{$fa-css-prefix}-plus-circle:before { content: $fa-var-plus-circle; }
+.#{$fa-css-prefix}-plus-circle:before { content: $fa-var-plus-circle; }
 .#{$fa-css-prefix}-minus-circle:before { content: $fa-var-minus-circle; }
 .#{$fa-css-prefix}-times-circle:before { content: $fa-var-times-circle; }
 .#{$fa-css-prefix}-check-circle:before { content: $fa-var-check-circle; }


### PR DESCRIPTION
The main purpose of this ticket is to add red boxes which indicate the coordinate of the searched-for SNP on the motif logos. It also calculates the reverse complement of motifs that have a negative strand value. The updates to the `d3-sequence-logos` library are made in the local version for debugging purposes but Regulome is actually using the installed version of the library not the local version. 

There are three other minor unrelated changes on this ticket.
(1) An issue with the data means that the back end returns an error for two overlapping SNPs (it should not) and I sort of patch that on the front end here (I print an error at least).
(2) Get rid of table title for QTLs on thumbnail when the table is empty.
(3) Fix bug where y-axis has too many tick marks when there is not much data.