### PR TITLE
REG-137 add filters to browser

### DIFF
--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -469,7 +469,7 @@ class GenomeBrowser extends React.Component {
                         {(this.state.disableBrowserForIE) ?
                             <div className="browser-error valis-browser">The genome browser does not support Internet Explorer. Please upgrade your browser to Edge to visualize files on ENCODE.</div>
                         :
-                            <div className="browser-error valis-browser">There are no visualizable results.</div>
+                            <div className="browser-error valis-browser">There are no visualizable results. Please try a different SNP or different search parameters.</div>
                         }
                     </div>
                 }

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -275,6 +275,11 @@ export const dbxrefPrefixMap = {
     WormBase: 'http://www.wormbase.org/species/c_elegans/strain/',
 };
 
+// Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
+export const sanitizedString = inputString => inputString.toLowerCase()
+    .replace(/ /g, '') // remove spaces (to allow multiple word searches)
+    .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
+
 
 // Keep lists of currently known project and biosample_type. As new project and biosample_type
 // enter the system, these lists must be updated. Used mostly to keep chart and matrix colors

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -577,15 +577,18 @@ const Facet = (props) => {
         <div className="facet">
             <h4>{facetTitle}</h4>
             <div className="facet-scrollable">
-                {facetArray.map(d =>
-                    <FacetButton
+                {facetArray.map((d) => {
+                    if (d === '') {
+                        return <hr />;
+                    }
+                    return <FacetButton
                         lookupFilterCount={lookupFilterCount}
                         selectedFacets={selectedFacets}
                         buttonLabel={d}
                         facetLabel={facetName}
                         addGenomeFilter={addGenomeFilter}
-                    />
-                )}
+                    />;
+                })}
             </div>
         </div>
     );
@@ -617,16 +620,19 @@ const TypeaheadFacet = (props) => {
                     className="term-list"
                     onScroll={shadeOverflowOnScroll}
                 >
-                    {facetArray.map(d =>
-                        <FacetButton
+                    {facetArray.map((d) => {
+                        if (d === '') {
+                            return <hr />;
+                        }
+                        return <FacetButton
                             lookupFilterCount={lookupFilterCount}
                             selectedFacets={selectedFacets}
                             buttonLabel={d}
                             facetLabel={facetName}
                             addGenomeFilter={addGenomeFilter}
                             key={d}
-                        />
-                    )}
+                        />;
+                    })}
                 </div>
                 <div className={`shading ${(facetArray.length < displayedTermsCount) ? 'hide-shading' : ''}`} />
             </div>
@@ -707,6 +713,9 @@ class GenomeFacets extends React.Component {
         this.lookupFilterCount = this.lookupFilterCount.bind(this);
         this.handleSearch = this.handleSearch.bind(this);
         this.createFacets = this.createFacets.bind(this);
+        this.isntZero = this.isntZero.bind(this);
+        this.isZero = this.isZero.bind(this);
+        this.placeZerosAtEnd = this.placeZerosAtEnd.bind(this);
     }
 
     componentDidMount() {
@@ -772,6 +781,25 @@ class GenomeFacets extends React.Component {
         return '';
     }
 
+    isntZero(arr, category) {
+        return arr.filter(el => this.lookupFilterCount(el, category) !== ' (0)');
+    }
+
+    isZero(arr, category) {
+        return arr.filter(el => this.lookupFilterCount(el, category) === ' (0)');
+    }
+
+    placeZerosAtEnd(arr, facet) {
+        let arrBegin = [...arr];
+        arrBegin = this.isntZero(arrBegin, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+        let arrEnd = [...arr];
+        arrEnd = this.isZero(arr, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+        if (arrBegin.length > 0 && arrEnd.length > 0) {
+            return [...arrBegin, '', ...arrEnd];
+        }
+        return [...arrBegin, ...arrEnd];
+    }
+
     createFacets(files) {
         // initialize facet object
         const facetObject = {};
@@ -807,11 +835,12 @@ class GenomeFacets extends React.Component {
                 });
             });
         });
-        // sort facet term names alphabetically, ignoring capitalization
+        const newFacetObject = {};
+        // sort facet term names by counts with zeros at the end
         facetList.forEach((facet) => {
-            facetObject[facet].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+            newFacetObject[facet] = this.placeZerosAtEnd(facetObject[facet], facet);
         });
-        return facetObject;
+        return newFacetObject;
     }
 
     render() {

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -571,21 +571,18 @@ FacetButton.propTypes = {
 };
 
 const Facet = (props) => {
-    const facetTitle = props.facetTitle;
-    const facetName = props.facetName;
-    const facetArray = props.facetArray;
-    const selectedFacets = props.selectedFacets;
+    const { facetTitle, facetName, facetArray, lookupFilterCount, addGenomeFilter, selectedFacets } = props;
     return (
         <div className="facet">
             <h4>{facetTitle}</h4>
             <div className="facet-scrollable">
                 {facetArray.map(d =>
                     <FacetButton
-                        lookupFilterCount={props.lookupFilterCount}
+                        lookupFilterCount={lookupFilterCount}
                         selectedFacets={selectedFacets}
                         buttonLabel={d}
                         facetLabel={facetName}
-                        addGenomeFilter={props.addGenomeFilter}
+                        addGenomeFilter={addGenomeFilter}
                     />
                 )}
             </div>

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -541,15 +541,19 @@ ResultsTable.defaultProps = {
 class FacetButton extends React.Component {
     constructor() {
         super();
-        this.addGenomeFilter = this.props.addGenomeFilter.bind(this);
+        this._addGenomeFilter = this._addGenomeFilter.bind(this);
+    }
+
+    _addGenomeFilter() {
+        this.props.addGenomeFilter(this.props.buttonLabel, this.props.facetLabel);
     }
 
     render() {
-        const { buttonLabel, facetLabel, lookupFilterCount, selectedFacets } = this.props;
+        const { buttonLabel, lookupFilterCount, selectedFacets, facetLabel } = this.props;
         return (
             <button
                 className={selectedFacets.includes(`${buttonLabel}AND${facetLabel}`) ? 'active' : ''}
-                onClick={this.addGenomeFilter(buttonLabel, facetLabel)}
+                onClick={this._addGenomeFilter}
                 disabled={(lookupFilterCount(buttonLabel, facetLabel) === ' (0)')}
             >
                 {buttonLabel}{lookupFilterCount(buttonLabel, facetLabel)}

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -550,13 +550,14 @@ class FacetButton extends React.Component {
 
     render() {
         const { buttonLabel, lookupFilterCount, selectedFacets, facetLabel } = this.props;
+        const filterCount = lookupFilterCount(buttonLabel, facetLabel);
         return (
             <button
                 className={selectedFacets.includes(`${buttonLabel}AND${facetLabel}`) ? 'active' : ''}
                 onClick={this._addGenomeFilter}
-                disabled={(lookupFilterCount(buttonLabel, facetLabel) === ' (0)')}
+                disabled={(filterCount === ' (0)')}
             >
-                {buttonLabel}{lookupFilterCount(buttonLabel, facetLabel)}
+                {buttonLabel}{filterCount}
             </button>
         );
     }

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -608,12 +608,14 @@ const TypeaheadFacet = (props) => {
     return (
         <div className="facet">
             <h4>{facetTitle}</h4>
-            <div className="typeahead-entry" role="search">
-                <i className="icon icon-search" />
-                <div className="searchform">
-                    <input type="search" aria-label={`Search to filter list of terms for ${facetName} facet`} placeholder="Search" value={unsanitizedSearchTerm} onChange={e => handleSearch(e, facetName)} name={`Search ${facetName} facet`} />
+            {((facetArray.length > displayedTermsCount) || (unsanitizedSearchTerm !== '')) ?
+                <div className="typeahead-entry" role="search">
+                    <i className="icon icon-search" />
+                    <div className="searchform">
+                        <input type="search" aria-label={`Search to filter list of terms for ${facetName} facet`} placeholder="Search" value={unsanitizedSearchTerm} onChange={e => handleSearch(e, facetName)} name={`Search ${facetName} facet`} />
+                    </div>
                 </div>
-            </div>
+            : null}
             <div className="facet-scrollable">
                 <div className="top-shading hide-shading" />
                 <div
@@ -794,10 +796,11 @@ class GenomeFacets extends React.Component {
         arrBegin = this.isntZero(arrBegin, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
         let arrEnd = [...arr];
         arrEnd = this.isZero(arr, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-        if (arrBegin.length > 0 && arrEnd.length > 0) {
-            return [...arrBegin, '', ...arrEnd];
-        }
-        return [...arrBegin, ...arrEnd];
+        return arrBegin;
+        // if (arrBegin.length > 0 && arrEnd.length > 0) {
+        //     return [...arrBegin, '', ...arrEnd];
+        // }
+        // return [...arrBegin, ...arrEnd];
     }
 
     createFacets(files) {

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -671,12 +671,12 @@ const filterByAllSelectedFilters = (files, facets) => {
 const filterByOneFilter = (files, facet) => {
     const facetFilter = facet.split('AND')[0];
     const facetName = facet.split('AND')[1];
-    let newFiles = files;
+    let newFiles;
     if (facetName === 'organ') {
-        newFiles = newFiles.filter(d => d[facetName].split(', ').some(f => facetFilter.includes(f)));
+        newFiles = files.filter(d => d[facetName].split(', ').some(f => facetFilter.includes(f)));
     // for non-organ facets, just check if the term matches the facet
     } else {
-        newFiles = newFiles.filter(d => facetFilter === d[facetName]);
+        newFiles = files.filter(d => facetFilter === d[facetName]);
     }
     return newFiles;
 };
@@ -811,10 +811,8 @@ class GenomeFacets extends React.Component {
     }
 
     placeZerosAtEnd(arr, facet) {
-        let arrBegin = [...arr];
-        arrBegin = this.isntZero(arrBegin, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-        let arrEnd = [...arr];
-        arrEnd = this.isZero(arr, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+        const arrBegin = this.isntZero(arr, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+        const arrEnd = this.isZero(arr, facet).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
         if (arrBegin.length > 0 && arrEnd.length > 0) {
             return [...arrBegin, '', ...arrEnd];
         }

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -661,6 +661,37 @@ const filterByAllSelectedFilters = (files, facets) => {
     return newFiles;
 };
 
+class FilterButton extends React.Component {
+    constructor() {
+        super();
+        this._addGenomeFilter = this._addGenomeFilter.bind(this);
+    }
+
+    _addGenomeFilter() {
+        this.props.addGenomeFilter(this.props.buttonLabel, this.props.facetLabel);
+    }
+
+    render() {
+        return (
+            <button
+                className="browser-filter"
+                onClick={this._addGenomeFilter}
+                key={this.props.facetKey}
+            >
+                <i className="icon icon-times-circle" />
+                {this.props.buttonLabel}
+            </button>
+        );
+    }
+}
+
+FilterButton.propTypes = {
+    buttonLabel: PropTypes.string.isRequired,
+    facetLabel: PropTypes.string.isRequired,
+    facetKey: PropTypes.string.isRequired,
+    addGenomeFilter: PropTypes.func.isRequired,
+};
+
 class GenomeFacets extends React.Component {
     constructor() {
         super();
@@ -794,14 +825,12 @@ class GenomeFacets extends React.Component {
                             {this.state.selectedFacets.map((f) => {
                                 const fsplit = f.split('AND');
                                 return (
-                                    <button
-                                        className="browser-filter"
-                                        onClick={() => this.addGenomeFilter(fsplit[0], fsplit[1])}
-                                        key={f}
-                                    >
-                                        <i className="icon icon-times-circle" />
-                                        {f.split('AND')[0]}
-                                    </button>
+                                    <FilterButton
+                                        buttonLabel={fsplit[0]}
+                                        facetLabel={fsplit[1]}
+                                        facetKey={f}
+                                        addGenomeFilter={this.addGenomeFilter}
+                                    />
                                 );
                             })}
                             <button

--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -13,7 +13,7 @@ const screenMediumMax = 787;
 const screenSmallMax = 483;
 
 // Number of terms to show, the rest will be viewable on scroll
-const displayedTermsCount = 5;
+const displayedTermsCount = 14;
 
 // Define facets (probably this should be in a schema really)
 const facetList = ['file_format', 'organ', 'biosample', 'assay', 'target'];

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import * as globals from './globals';
 import { ResultsTable } from './regulome_search';
 import { isLight } from './datacolors';
+
+const sanitizedString = globals.sanitizedString;
 
 const mapChromatinNames = {
     TssAFlnk: 'Flanking Active TSS',
@@ -376,11 +379,6 @@ function filterForKey(element, key, dataFilter) {
     return false;
 }
 
-// Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
-const sanitizedString = inputString => inputString.toLowerCase()
-    .replace(/ /g, '') // remove spaces (to allow multiple word searches)
-    .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
-
 // Display information on page as JSON formatted data
 export class ChartList extends React.Component {
     constructor(props, context) {
@@ -497,7 +495,7 @@ export class ChartList extends React.Component {
     }
 
     render() {
-        const searchTerm = String(sanitizedString(this.state.unsanitizedSearchTerm));
+        const searchTerm = String(globals.sanitizedString(this.state.unsanitizedSearchTerm));
         let errorMessage = !!searchTerm;
         let fillColor;
         if (this.props.dataFilter === 'dnase') {
@@ -527,7 +525,7 @@ export class ChartList extends React.Component {
                     const dKey = d.replace(/[^\w\s]/gi, '').toLowerCase();
                     let searchTermMatch = true;
                     if (searchTerm) {
-                        searchTermMatch = sanitizedString(d).match(searchTerm);
+                        searchTermMatch = globals.sanitizedString(d).match(searchTerm);
                         if (searchTermMatch) {
                             errorMessage = false;
                         }

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -495,7 +495,7 @@ export class ChartList extends React.Component {
     }
 
     render() {
-        const searchTerm = String(globals.sanitizedString(this.state.unsanitizedSearchTerm));
+        const searchTerm = String(sanitizedString(this.state.unsanitizedSearchTerm));
         let errorMessage = !!searchTerm;
         let fillColor;
         if (this.props.dataFilter === 'dnase') {
@@ -525,7 +525,7 @@ export class ChartList extends React.Component {
                     const dKey = d.replace(/[^\w\s]/gi, '').toLowerCase();
                     let searchTermMatch = true;
                     if (searchTerm) {
-                        searchTermMatch = globals.sanitizedString(d).match(searchTerm);
+                        searchTermMatch = sanitizedString(d).match(searchTerm);
                         if (searchTermMatch) {
                             errorMessage = false;
                         }

--- a/src/encoded/static/scss/bootstrap/_navbar.scss
+++ b/src/encoded/static/scss/bootstrap/_navbar.scss
@@ -127,7 +127,7 @@
   position: fixed;
   right: 0;
   left: 0;
-  z-index: $zindex-navbar-fixed;
+  z-index: 9999;
 
   // Undo the rounded corners
   @media (min-width: $grid-float-breakpoint) {

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -298,6 +298,10 @@
     position: relative;
 }
 
+.term-list {
+    position: relative;
+}
+
  .shading {
     padding-bottom: 2px;
     bottom: 0;

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -64,12 +64,12 @@
 }
 
 .hpgv_track-sequence {
-    --nucleobase-a: #0C7489;
-    --nucleobase-t: #F9CE70;
-    --nucleobase-g: #0FA3B1;
-    --nucleobase-c: #C14953;
-    --gc-banding-low: #0C7489;
-    --gc-banding-high: #F9CE70;
+    --nucleobase-a: #C13B42;
+    --nucleobase-t: #489655;
+    --nucleobase-g: #335C95;
+    --nucleobase-c: #EFB549;
+    --gc-banding-low: #EFB549;
+    --gc-banding-high: #C13B42;
     --text-color: rgba(255, 255, 255, 0.7);
     --text-additive-blending: 0; /* set to 0.0 for dark text colors */
 }

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -12,8 +12,8 @@
 
 .valis-browser {
     width: 100%;
-    min-height: 200px;
-    margin-top: 5px;
+    min-height: 400px;
+    margin-top: 40px;
     button {
         svg {
             margin-left: 0 !important;
@@ -206,8 +206,13 @@
 
 .valis-browser {
     &.browser-error {
-        margin: 30px 20px;
-        text-align: left;
+        margin: 30px auto;
+        background: #f2f2f2;
+        border-radius: 5px;
+        padding: 20px;
+        font-size: 1.3rem;
+        border: 1px solid #ddd;
+        min-height: 400px;
     }
 }
 
@@ -260,4 +265,31 @@
 
 .tall-browser-container {
     min-height: 1200px;
+}
+
+.filter-browser-files, .browser-selections-container {
+    max-width: 1000px;
+    margin: 10px auto;
+    .browser-facet {
+        display: inline-block;
+        padding: 5px 10px 2px;
+        margin: 0 10px;
+        border-bottom: 2px solid black;
+        background: #f2f2f2;
+        font-weight: 700;
+        ul {
+            display: none;
+        }
+    }
+    .filter-hed {
+        display: inline-block;
+    }
+    .filter-link {
+        margin: 0 10px;
+        display: inline-block;
+    }
+}
+
+.filter-browser-files {
+    margin-bottom: 40px;
 }

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -212,7 +212,7 @@
         padding: 20px;
         font-size: 1.3rem;
         border: 1px solid #ddd;
-        min-height: 400px;
+        min-height: 450px;
     }
 }
 

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -64,10 +64,10 @@
 }
 
 .hpgv_track-sequence {
-    --nucleobase-a: #C13B42;
-    --nucleobase-t: #489655;
-    --nucleobase-g: #335C95;
-    --nucleobase-c: #EFB549;
+    --nucleobase-a: #489655;
+    --nucleobase-t: #C13B42;
+    --nucleobase-g: #EFB549;
+    --nucleobase-c: #335C95;
     --gc-banding-low: #EFB549;
     --gc-banding-high: #C13B42;
     --text-color: rgba(255, 255, 255, 0.7);

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1441,7 +1441,7 @@ button {
                 background: linear-gradient(rgba(0,0,0,0), 70%, rgba(0,0,0,0.8));
             }
             .term-list {
-                max-height: 200px;
+                max-height: 400px;
                 overflow-y: scroll;
                 cursor: default;
             }

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1432,6 +1432,8 @@ button {
             }
             &:disabled {
                 color: #B9B9B9;
+                font-weight: 400;
+                font-style: italic;
             }
         }
         input {

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -625,7 +625,7 @@ table {
 }
 
 .adv-search-form {
-    max-width: 1000px;
+    max-width: 1076px;
     margin: auto;
 }
 
@@ -635,7 +635,7 @@ table {
 }
 
 .sequence-logo-table, .error-message {
-    max-width: 1000px;
+    max-width: 1076px;
     margin: auto;
 }
 
@@ -889,7 +889,7 @@ table {
 }
 
 .search-information {
-    max-width: 1000px;
+    max-width: 1076px;
     margin: auto;
     .notification-line {
         display: flex;
@@ -960,7 +960,7 @@ button {
     font-size: 16px;
     margin: 0 auto;
     color: $regulomeGreen;
-    &:hover {
+    &:hover:enabled {
         font-weight: 700;
         text-decoration: underline;
         cursor: pointer;
@@ -973,7 +973,7 @@ button {
 }
 
 .svg-container {
-    max-width: 1000px;
+    max-width: 1076px;
     width: 100%;
     margin: auto;
     margin-top: 30px;
@@ -1003,7 +1003,8 @@ button {
         }
         .bold-label {
             font-weight: 700;
-            fill: rgb(193, 59, 66);
+            fill: white;
+            font-size: 14px;
         }
     }
 }
@@ -1067,7 +1068,7 @@ button {
     }
 }
 .bar-chart-container, h4 {
-    max-width: 1000px;
+    max-width: 1076px;
     margin-left: auto;
     margin-right: auto;
 }
@@ -1332,4 +1333,149 @@ button {
 .panel {
     box-shadow: none;
     -webkit-box-shadow: none;
+}
+
+.browser-selections {
+    max-width: 1076px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 5px 10px;
+    display: block;
+    text-align: left;
+    font-style: italic;
+    font-weight: 400;
+    background: #2E4C7A;
+    color: white;
+    border-radius: 5px;
+    opacity: 0.95;
+    &.facets-without-border {
+        border-radius: 0;
+        border-top-right-radius: 5px;
+        border-top-left-radius: 5px;
+    }
+    .icon {
+        margin-right: 10px;
+        font-size: 20px;
+        width: 10px;
+    }
+    .selection-header {
+        font-style: normal;
+        font-weight: 200;
+        text-transform: uppercase;
+    }
+}
+
+.browser-facet-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 1076px;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+    margin: auto;
+    margin-bottom: 40px;
+    background: #2E4C7A;
+    color: white;
+    position: absolute;
+    width: 100%;
+    left: 0;
+    right: 0;
+    opacity: 0.95;
+    z-index: 99999;
+    @media screen and (max-width: 1096px) {
+        width: calc(100% - 20px);
+    }
+    .facet {
+        flex: 0 1 20%;
+        @media screen and (max-width: $screen-sm-min) {
+            flex: 0 1 100%;
+        }
+        padding: 10px;
+        border-radius: 3px;
+        border: none;
+        margin: 0 auto;
+        cursor: default;
+        h4 {
+            font-size: 1.1rem;
+            text-align: left;
+            font-weight: 400;
+            border-bottom: 1px solid #c0c0c0;
+            @media screen and (max-width: $screen-sm-min) {
+                font-size: 0.9rem;
+            }
+        }
+        button {
+            display: block;
+            margin: 4px 4px 0;
+            line-height: 1;
+            padding: 5px 5px 2px;
+            font-size: 1rem;
+            text-align: left;
+            color: white;
+            border: 2px solid rgba(46,76,122,0);
+            @media screen and (max-width: $screen-sm-min) {
+                font-size: 0.8rem;
+                padding: 5px 3px 2px;
+            }
+            &.active {
+                border: 2px solid white;
+                color: white;
+                border-radius: 5px;
+            }
+            &:empty {
+                display: none;
+            }
+            &:disabled {
+                color: #B9B9B9;
+            }
+        }
+        input {
+            color: black;
+            @media screen and (max-width: $screen-sm-min) {
+                font-size: 0.9rem;
+            }
+        }
+        .facet-scrollable {
+            position: relative;
+            .shading {
+                background: linear-gradient(rgba(0,0,0,0), 70%, rgba(0,0,0,0.8));
+            }
+            .term-list {
+                max-height: 200px;
+                overflow-y: scroll;
+                cursor: default;
+            }
+            .top-shading {
+                background: linear-gradient(rgba(0,0,0,0.8), 30%, rgba(0,0,0,0));
+            }
+        }
+    }
+}
+
+.browser-selected-facets {
+    max-width: 1076px;
+    margin: auto;
+    text-align: left;
+    padding-bottom: 20px;
+    .browser-filter {
+        padding: 0;
+        margin-left: 10px;
+        color: #2E4C7A;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        i {
+            padding-right: 3px;
+        }
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    &.warning {
+        font-weight: 600;
+        color: #c13b42;
+        .icon {
+            padding-right: 3px;
+        }
+    }
 }

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1381,7 +1381,7 @@ button {
     left: 0;
     right: 0;
     opacity: 0.95;
-    z-index: 99999;
+    z-index: 9998;
     @media screen and (max-width: 1096px) {
         width: calc(100% - 20px);
     }

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1404,6 +1404,11 @@ button {
                 font-size: 0.9rem;
             }
         }
+        hr {
+            margin-top: 10px;
+            margin-bottom: 10px;
+            border-top: 1px solid #c0c0c0;
+        }
         button {
             display: block;
             margin: 4px 4px 0;


### PR DESCRIPTION
Creates facets for the genome browser:
- File type
- Organ (typeahead)
- Biosample (typeahead)
- Method
- Target (typeahead)

There are also some very minor style changes:
- I added a background on the searched-for SNP on the line diagram
- I fixed the width of the SNP annotation background rectangles to be more accurate on the line diagram
- I moved the pagination buttons and "Page X of Y" to be stacked