### PR TITLE
REG-163 fix discrepancy in MAF cutoff

### DIFF
--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -23,7 +23,7 @@ const dataTypeStrings = [
     },
     {
         type: 'A chromosomal region',
-        explanation: 'Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based coordinates. All dbSNP IDs with an minor allele frequency >0.05 that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNPs.',
+        explanation: 'Enter hg19 chromosomal regions, such as a promoter region upstream of a gene, as 0-based coordinates. All dbSNP IDs with an minor allele frequency >1% that are found in this region will be used to identify DNA features and regulatory elements that contain the coordinate of the SNPs.',
     },
 ];
 


### PR DESCRIPTION
MAF cutoff was incorrectly transcribed to be 5% in the new beta site, but it should be 1%