### PR TITLE
REG-164 update motif colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2884,7 +2884,7 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-sequence-logo": {
-      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#6d25a48ab9f7d6b0e695331dde77080f34339ae6",
+      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#68f19e0f9de676af55719923346ba228f0cb2bae",
       "from": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#REG-71-add-pwm-logos",
       "requires": {
         "d3": "^3.3.8"

--- a/src/encoded/static/libs/d3-sequence-logo.js
+++ b/src/encoded/static/libs/d3-sequence-logo.js
@@ -230,10 +230,10 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
     const svgLetterHeight = 150;
 
     const colorBase = {
-        A: '#C13B42',
-        C: '#EFB549',
-        G: '#335C95',
-        T: '#489655',
+        A: '#489655',
+        C: '#335C95',
+        G: '#EFB549',
+        T: '#C13B42',
     };
 
     const lookupBaseColor = (i) => {


### PR DESCRIPTION
We want all the base pair colors to match (on the logos and on the genome browser):
A = green
G = yellow
T = red
C = blue