### PR TITLE
REG-173 accessibility page redesign

### DIFF
--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -605,9 +605,6 @@ export class ChartList extends React.Component {
                                             <p><span className="table-label">Organ</span>{d2.biosample_ontology.organ_slims.join(', ')}</p>
                                         : null}
                                         <p><span className="table-label">Method</span>{d2.method}</p>
-                                        {d2.biosample_ontology ?
-                                            <p><span className="table-label">Biosample</span>{d2.biosample_ontology.term_name}</p>
-                                        : null}
                                         {(d2.chrom && this.props.dataFilter === 'chromatin') ?
                                             <p><span className="table-label">Chromatin state window</span>{d2.chrom}:{d2.start}..{d2.end}</p>
                                         : null}
@@ -628,7 +625,6 @@ export class ChartList extends React.Component {
                                         <th>Dataset</th>
                                         <th>Organ</th>
                                         <th>Method</th>
-                                        <th>Biosample</th>
                                         {(this.props.dataFilter === 'chromatin') ?
                                             <th>Chromatin state window</th>
                                         : null}
@@ -639,7 +635,6 @@ export class ChartList extends React.Component {
                                             <td><a href={d2.dataset}>{d2.dataset.split('/')[2]}</a></td>
                                             <td>{d2.biosample_ontology.organ_slims.join(', ')}</td>
                                             <td>{d2.method}</td>
-                                            <td>{d2.biosample_ontology.term_name}</td>
                                             {(this.props.dataFilter === 'chromatin') ?
                                                 <td>{d2.chrom}:{d2.start}..{d2.end}</td>
                                             : null}

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -591,10 +591,7 @@ export class ChartList extends React.Component {
                                 </div>
                             </div>
                             <div
-                                className={`barchart-table ${this.state.currentTarget.includes(`table${dKey}`) ? 'active' : ''}`}
-                                style={{
-                                    marginLeft: `${leftMargin}px`,
-                                }}
+                                className={`mobile-display barchart-table ${this.state.currentTarget.includes(`table${dKey}`) ? 'active' : ''}`}
                                 id={`barchart-table-${dKey}`}
                                 aria-labelledby={`barchart-button-${dKey}`}
                             >
@@ -620,6 +617,36 @@ export class ChartList extends React.Component {
                                     </div>
                                 )}
                             </div>
+                            <table
+                                className={`desktop-display barchart-table ${this.state.currentTarget.includes(`table${dKey}`) ? 'active' : ''}`}
+                                id={`barchart-table-${dKey}`}
+                                aria-labelledby={`barchart-button-${dKey}`}
+                            >
+                                <tbody>
+                                    <tr>
+                                        <th>File</th>
+                                        <th>Dataset</th>
+                                        <th>Organ</th>
+                                        <th>Method</th>
+                                        <th>Biosample</th>
+                                        {(this.props.dataFilter === 'chromatin') ?
+                                            <th>Chromatin state window</th>
+                                        : null}
+                                    </tr>
+                                    {this.state.data.filter(element => filterForKey(element, d, this.props.dataFilter)).map(d2 =>
+                                        <tr key={d2.file}>
+                                            <td><a href={`../files/${d2.file}`}>{d2.file}</a></td>
+                                            <td><a href={d2.dataset}>{d2.dataset.split('/')[2]}</a></td>
+                                            <td>{d2.biosample_ontology.organ_slims.join(', ')}</td>
+                                            <td>{d2.method}</td>
+                                            <td>{d2.biosample_ontology.term_name}</td>
+                                            {(this.props.dataFilter === 'chromatin') ?
+                                                <td>{d2.chrom}:{d2.start}..{d2.end}</td>
+                                            : null}
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
                         </div>
                     );
                 })}

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as globals from './globals';
 import _ from 'underscore';
+import * as globals from './globals';
 import { ResultsTable } from './regulome_search';
 import { isLight } from './datacolors';
 

--- a/src/encoded/static/components/visualizations.js
+++ b/src/encoded/static/components/visualizations.js
@@ -412,7 +412,7 @@ export class ChartList extends React.Component {
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.updateWidth);
+        window.removeEventListener('resize', _.debounce(() => this.updateWidth(), 10));
     }
 
     updateWidth() {
@@ -420,6 +420,7 @@ export class ChartList extends React.Component {
     }
 
     handleClick(clickID) {
+        this.updateWidth();
         if (!(this.state.currentTarget.includes(`table${clickID}`))) {
             this.setState(prevState => ({
                 currentTarget: [...prevState.currentTarget, `table${clickID}`],
@@ -443,6 +444,7 @@ export class ChartList extends React.Component {
     }
 
     expandTerms() {
+        this.updateWidth();
         const allTargets = Object.keys(this.state.chartData).map((key) => {
             const dKey = key.replace(/[^\w\s]/gi, '').toLowerCase();
             return `table${dKey}`;

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1131,6 +1131,20 @@ button {
             }
         }
     }
+    tr {
+        border-bottom: 1px solid #ACACAC;
+    }
+    &.mobile-display {
+        display: none;
+        @media screen and (max-width: 600px) {
+            display: block;
+        }
+    }
+    &.desktop-display {
+        @media screen and (max-width: 600px) {
+            display: none;
+        }
+    }
 }
 
 .table-list {

--- a/src/encoded/static/scss/encoded/modules/_regulome_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_search.scss
@@ -1134,17 +1134,6 @@ button {
     tr {
         border-bottom: 1px solid #ACACAC;
     }
-    &.mobile-display {
-        display: none;
-        @media screen and (max-width: 600px) {
-            display: block;
-        }
-    }
-    &.desktop-display {
-        @media screen and (max-width: 600px) {
-            display: none;
-        }
-    }
 }
 
 .table-list {


### PR DESCRIPTION
On the accessibility tab, we're replacing the lists of results with tables, and moving the tables to the left so there is less confusing white space.
We're keeping the lists of results for mobile, however, since the tables are too wide for good mobile viewing.