### PR TITLE
REG-178 fix motif error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2884,7 +2884,7 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-sequence-logo": {
-      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#68f19e0f9de676af55719923346ba228f0cb2bae",
+      "version": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#e9fff11b41b472c5042230108edc1141f4de6b1d",
       "from": "git://github.com/ENCODE-DCC/d3-sequence-logo.git#REG-71-add-pwm-logos",
       "requires": {
         "d3": "^3.3.8"

--- a/src/encoded/static/libs/d3-sequence-logo.js
+++ b/src/encoded/static/libs/d3-sequence-logo.js
@@ -84,6 +84,7 @@ function offsets(counts, maxCount) {
     let H = 0;
     const sumCounts = counts.reduce((a, b) => +a + +b, 0);
     counts.forEach((d) => {
+        // we are adding an epsilon of 0.25 because that is consistent with the University of Michigan's implementation
         const relativeFrequency = (d + 0.25) / sumCounts;
         H -= relativeFrequency * Math.log2(relativeFrequency);
     });
@@ -94,6 +95,7 @@ function offsets(counts, maxCount) {
     let offsetFromTop = 0;
     counts.forEach((d, j) => {
         // relative frequency for base at position i
+        // we are adding an epsilon of 0.25 because that is consistent with the University of Michigan's implementation
         const relativeFrequency = (d + 0.25) / sumCounts;
         // height of letter
         const height = relativeFrequency * R;
@@ -101,7 +103,7 @@ function offsets(counts, maxCount) {
         // calculate offset from the top
         // (maxCount / 2) is for the purposes of 'entryPoint'
         // 'entryPoint' scales each letter by the max PWM value
-        // therefore we need to here we translate our values in the range [0,2] to be in the range [0, maxCount]
+        // therefore we need to translate our values in the range [0,2] to be in the range [0, maxCount]
         const dnew = height * (maxCount / 2);
         offsetFromTop += dnew;
 

--- a/src/encoded/static/libs/d3-sequence-logo.js
+++ b/src/encoded/static/libs/d3-sequence-logo.js
@@ -76,30 +76,33 @@ function getLetterPath(i, strand) {
  * @param {number} i - letter index. Range: [0,4)
  * @returns {number[][]} counts of each letter.
  */
-function offsets(cnts, maxCount) {
+function offsets(counts, maxCount) {
     const offs = [];
-
     let ctr = 0;
-    let en = 0; // 1 / 0.69314718056 * (4 - 1) / (2 * maxCount);
 
+    // compute H, the uncertainty of a position
     let H = 0;
-
-    cnts.forEach((d) => {
-        const relativeFrequency = d / maxCount;
-        if (relativeFrequency > 0) {
-            H -= relativeFrequency * Math.log2(relativeFrequency);
-        }
+    const sumCounts = counts.reduce((a, b) => +a + +b, 0);
+    counts.forEach((d) => {
+        const relativeFrequency = (d + 0.25) / sumCounts;
+        H -= relativeFrequency * Math.log2(relativeFrequency);
     });
+    // compute information content of position
+    const R = 2 - H;
 
-    // add on the index so we can use it.
-    // determine heights of rects
+    // determine heights of rectangles
     let offsetFromTop = 0;
-    cnts.forEach((d, j) => {
-        let dnew = 0;
-        if (d > 0) {
-            const relativeFrequency = d / maxCount;
-            dnew = (2 - H) * relativeFrequency * (maxCount / 2); // maxCount/2 is scaling factor
-        }
+    counts.forEach((d, j) => {
+        // relative frequency for base at position i
+        const relativeFrequency = (d + 0.25) / sumCounts;
+        // height of letter
+        const height = relativeFrequency * R;
+
+        // calculate offset from the top
+        // (maxCount / 2) is for the purposes of 'entryPoint'
+        // 'entryPoint' scales each letter by the max PWM value
+        // therefore we need to here we translate our values in the range [0,2] to be in the range [0, maxCount]
+        const dnew = height * (maxCount / 2);
         offsetFromTop += dnew;
 
         const nextCtr = ctr + dnew;


### PR DESCRIPTION
The sequence logo heights were not being computed quite correctly, the code was using a maximum instead of a summation to compute the relative frequencies.