### PR TITLE
Removing proxy servers for downloads

### DIFF
--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -173,10 +173,6 @@ class File(Item):
         "type": "string",
     })
     def href(self, request, file_format, accession=None, external_accession=None):
-        s3_uri = self.s3_uri()
-        if s3_uri:
-            return s3_uri
-
         accession = accession or external_accession
         file_extension = self.schema['file_format_file_extension'][file_format]
         filename = '{}{}'.format(accession, file_extension)

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -173,6 +173,10 @@ class File(Item):
         "type": "string",
     })
     def href(self, request, file_format, accession=None, external_accession=None):
+        s3_uri = self.s3_uri()
+        if s3_uri:
+            return s3_uri
+
         accession = accession or external_accession
         file_extension = self.schema['file_format_file_extension'][file_format]
         filename = '{}{}'.format(accession, file_extension)


### PR DESCRIPTION
Part of the migration of Regulome into the new AWS account.

Preventing downloads to be redirected to the old download server:
https://download.encodeproject.org/<signed s3 uri>