### PR TITLE
REG-237-clean-cloud-config

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -3,47 +3,7 @@ ssh_authorized_keys:
   - %(LOCAL_SSH_KEY)s
 bootcmd:
 - set -ex
-- cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
-- cloud-init-per once chmod-swapfile chmod 600 /swapfile
-- cloud-init-per once mkswap-swapfile mkswap /swapfile
-- cloud-init-per once curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-package_upgrade: true
-packages:
-- apache2
-- awscli
-- libarchive-tools
-- build-essential
-- git
-- graphviz
-- libapache2-mod-wsgi-py3
-- libcurl4-gnutls-dev
-- libevent-dev
-- libfreetype6-dev
-- libjpeg-dev
-- liblcms2-dev
-- libmagic-dev
-- libpq-dev
-- libssl-dev
-- libtiff5-dev
-- libwebp-dev
-- libxml2-dev
-- libxslt1-dev
-- lzop
-- nodejs
-- npm
-- ntp
-- pv
-- python2.7-dev
-- python3-dev
-- python3-pip
-- software-properties-common
-- python3-virtualenv
-- ruby-dev
-- unattended-upgrades
-- update-notifier-common
-- zlib1g-dev
-- libffi-dev
-- bsd-mailx
+- echo "Booting"
 power_state:
   mode: reboot
 output:
@@ -51,7 +11,6 @@ output:
 runcmd:
 - sudo -u ubuntu mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
 - sudo -u ubuntu aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
-  # Manually install java
 - sudo -u ubuntu mkdir /home/ubuntu/.aws
 - sudo -u ubuntu aws s3 cp --region=us-west-2 s3://regulome-conf-prod/.aws-regulome/credentials ~ubuntu/.aws
 - sudo -u ubuntu rm -r /home/ubuntu/.aws

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -43,13 +43,6 @@ runcmd:
 - a2disconf localized-error-pages
 - a2disconf other-vhosts-access-log
 - a2disconf serve-cgi-bin
-- sudo sed -i -e 's/inet_interfaces = all/inet_interfaces = loopback-only/g' /etc/postfix/main.cf
-- PUBLIC_DNS_NAME="$(curl http://169.254.169.254/latest/meta-data/public-hostname)"
-- sudo sed -i "/myhostname/c\myhostname = $PUBLIC_DNS_NAME" /etc/postfix/main.cf
-- sudo echo "127.0.0.0 $PUBLIC_DNS_NAME" | sudo tee --append /etc/hosts
-- sudo mv /etc/mailname /etc/mailname.OLD
-- sudo echo "$PUBLIC_DNS_NAME" | sudo tee --append /etc/mailname
-- sudo service postfix restart
 users:
 - default
 - name: build
@@ -71,7 +64,6 @@ write_files:
     Unattended-Upgrade::Allowed-Origins {
         "${distro_id} ${distro_codename}-security";
     };
-    Unattended-Upgrade::Mail "encode-devops@lists.stanford.edu";
     Unattended-Upgrade::Automatic-Reboot "false";
 - path: /etc/cron.d/cloudwatchmon
   content: |

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -426,7 +426,7 @@ def parse_args():
     parser.add_argument('-n', '--name', type=hostname, help="Instance name")
     parser.add_argument('--dry-run-aws', action='store_true', help="Abort before ec2 requests.")
     parser.add_argument('--check-price', action='store_true', help="Check price on spot instances")
-    parser.add_argument('--image-id', default='ami-0964546d3da97e3ab', help="Default machine is ubuntu 20.04")
+    parser.add_argument('--image-id', default='ami-012af15928e0c2823', help="packer AMI build")
     parser.add_argument('--instance-type', default='t2.medium',
                         help="AWS Instance type")
     parser.add_argument('--profile-name', default=None, help="AWS creds profile")


### PR DESCRIPTION
Remove package installations that are now already done in the AMI. We do not need to configure postfix, it is not installed anymore.