### PR TITLE
REG-241 update valis version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8551,8 +8551,8 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#2f507425d6ff27fe380508fa3dfe271161253c78",
-      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.8.0",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#1218e55ea35640893559d8e76174993a43a346ac",
+      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.9.0",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "dagre-d3": "git://github.com/ENCODE-DCC/dagre-d3.git#use-local-d3",
     "domready": "^0.3.0",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.8.0",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.9.0",
     "google-analytics": "file:node_shims/google-analytics",
     "immutable": "^3.7.5",
     "jsonschema": "^1.1.0",

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -319,7 +319,10 @@ TrackLabel.propTypes = {
 class GenomeBrowser extends React.Component {
     constructor(props, context) {
         super(props, context);
-
+        const highlightLocationStart = +props.coordinates.split(':')[1].split('-')[0];
+        const highlightLocationEnd = +props.coordinates.split(':')[1].split('-')[1];
+        const x0 = highlightLocationStart - 5000;
+        const x1 = highlightLocationEnd + 5000;
         this.state = {
             trackList: [],
             visualizer: null,
@@ -327,8 +330,10 @@ class GenomeBrowser extends React.Component {
             searchTerm: '',
             genome: '',
             contig: props.coordinates.split(':')[0],
-            x0: +props.coordinates.split(':')[1].split('-')[0] - 5000,
-            x1: +props.coordinates.split(':')[1].split('-')[1] + 5000,
+            x0: x0,
+            x1: x1,
+            highlightLocationStart: highlightLocationStart,
+            highlightLocationEnd: highlightLocationEnd,
             pinnedFiles: [],
             disableBrowserForIE: false,
             geneSearch: false,
@@ -563,8 +568,9 @@ class GenomeBrowser extends React.Component {
     }
 
     drawTracks(container) {
-        const highlightLocation = Math.floor((this.state.x1 + this.state.x0) / 2) + 1; // browser uses base 1
-        const highlightString = `${this.state.contig}:${highlightLocation}`;
+        const highlightLocationStart = this.state.highlightLocationStart;
+        const highlightLocationEnd = this.state.highlightLocationEnd;
+        const highlightString = `${this.state.contig}:${highlightLocationStart}-${highlightLocationEnd}`;
         const visualizer = new this.GV.GenomeVisualizer({
             clampToTracks: true,
             reorderTracks: true,


### PR DESCRIPTION
Updating Regulome to the new Valis release and incorporating @leepc12's updates to use a highlight range instead of a highlight coordinate