### PR TITLE
more updates to REGD-50

### DIFF
--- a/src/encoded/static/libs/d3-sequence-logo.js
+++ b/src/encoded/static/libs/d3-sequence-logo.js
@@ -190,27 +190,26 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
     // if (!isValid) {
     //   return;
     // }
-
+    
     // number of sequences
     let n = 0;
     PWM.forEach((pwm) => {
         n = Math.max(n, Math.max(...pwm));
     });
-
+    
     // if the strand is negative, we want the reverse complement
     if (strand === '-') {
         PWM.reverse();
     }
-
+    
     // number of nucleotides per sequence
     const m = PWM.length;
-
+    
     // range of letter bounds at each nucleotide index position
     const yz = d3.range(m).map(i => offsets(PWM[i], n));
-
+    
     // find coordinate index
     const alignmentIndex = +alignmentCoordinate - +firstCoordinate;
-
     /**
    * Next, we set local values that govern visual appearance.
    *
@@ -307,6 +306,17 @@ function entryPoint(logoSelector, PWM, d3, alignmentCoordinate, firstCoordinate,
                 .attr('stroke-width', '4px')
                 .attr('transform', `translate(${xscale(pIdx)},0)`);
         });
+
+        // append black rectangle around the alignment index box
+        svg.append('rect')
+            .attr('y', '-1px')
+            .attr('x', '-1px')
+            .attr('width', `${(svgLetterWidth / m) + 2}px`)
+            .attr('height', `${(svgFullHeight - 20)}px`)
+            .attr('fill', 'none')
+            .attr('stroke-width', '4px')
+            .attr('stroke', 'black')
+            .attr('transform', `translate(${xscale(alignmentIndex)},0)`);
     }
 
     // Attach left endpoint to SVG

--- a/src/encoded/static/scss/encoded/modules/_regulome_motifs.scss
+++ b/src/encoded/static/scss/encoded/modules/_regulome_motifs.scss
@@ -101,3 +101,25 @@
     margin-top: -20px;
     padding-bottom: 20px;
 }
+
+.motif-label-row  {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-content: stretch;
+    align-items: flex-start;
+}
+
+.motif-label-col {
+    font-weight: 300;
+    font-size: 14px;
+    margin-right: 5px;
+    order: 0;
+    flex: 1 1 33.33%;
+    align-self: auto;
+
+    a {
+        font-weight: 600;
+    }
+}


### PR DESCRIPTION
* Target, Strand, and Pwm components separated for easier reading
* Target, Strand, and Pwm components also aligned into 3 columns on one line in each motif result
* The name of the Assembly Reference is set based on how the search is done (hg19 or GRCh38)
* A Black border surrounds the aligned sequence element in the reference to match the red rectangle in the sequence logo