### PR TITLE
REGD-91 genome browser fix target display

### DIFF
--- a/src/encoded/static/components/regulome_search.js
+++ b/src/encoded/static/components/regulome_search.js
@@ -737,6 +737,13 @@ export class RegulomeSearch extends React.Component {
             let filesForGenomeBrowser = [];
             experimentDatasets.forEach((dataset) => {
                 const files = dataset.files_for_genome_browser;
+                let target = '';
+                // use target labels instead of gene symbols for histone ChIP-seq targets
+                if (dataset.method === 'Histone ChIP-seq') {
+                    target = dataset.target_label ? dataset.target_label : '';
+                } else {
+                    target = dataset.targets ? dataset.targets.join(', ') : '';
+                }
                 // eslint-disable-next-line no-plusplus
                 for (let i = 0; i < files.length; i++) {
                     files[i].assay_term_name = dataset.method;
@@ -744,7 +751,7 @@ export class RegulomeSearch extends React.Component {
                     files[i].file_format = files[i].href.split('.')[1];
                     files[i].dataset = dataset.dataset_rel;
                     files[i].title = files[i].accession;
-                    files[i].target = dataset.targets ? dataset.targets.join(', ') : '';
+                    files[i].target = target;
                     files[i].biosample = dataset.biosample_ontology.term_name || '';
                     files[i].assay = dataset.method || '';
                     files[i].organ = (dataset.biosample_ontology.classification === 'tissue') ? dataset.biosample_ontology.organ_slims.join(', ') : dataset.biosample_ontology.cell_slims.join(', ');


### PR DESCRIPTION
Used target labels instead of gene symbols for histone ChIP-seq datasets under the genome browser view